### PR TITLE
동그란 이미지 프로필 구현

### DIFF
--- a/Mogakco/Mogakco.xcodeproj/project.pbxproj
+++ b/Mogakco/Mogakco.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		CBA64FFF2923805D000FEEAD /* UILabel+LineSpacing.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBA64FFE2923805D000FEEAD /* UILabel+LineSpacing.swift */; };
 		CBA64FFB292364CA000FEEAD /* SetEmailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBA64FFA292364CA000FEEAD /* SetEmailViewController.swift */; };
 		CBA64FBF2922FC2A000FEEAD /* CountTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBA64FBE2922FC2A000FEEAD /* CountTextField.swift */; };
+		34CFD054292280C0007CF0F0 /* RoundProfileImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34CFD053292280C0007CF0F0 /* RoundProfileImage.swift */; };
 		D8244537292244FC005EE8F1 /* UIFont+CustomFont.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8244536292244FC005EE8F1 /* UIFont+CustomFont.swift */; };
 		D824453B29224522005EE8F1 /* SFProDisplay-Regular.OTF in Resources */ = {isa = PBXBuildFile; fileRef = D824453929224522005EE8F1 /* SFProDisplay-Regular.OTF */; };
 		D824453C29224522005EE8F1 /* SFProDisplay-Semibold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = D824453A29224522005EE8F1 /* SFProDisplay-Semibold.ttf */; };
@@ -83,6 +84,7 @@
 		CBA64FFE2923805D000FEEAD /* UILabel+LineSpacing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILabel+LineSpacing.swift"; sourceTree = "<group>"; };
 		CBA64FFA292364CA000FEEAD /* SetEmailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetEmailViewController.swift; sourceTree = "<group>"; };
 		CBA64FBE2922FC2A000FEEAD /* CountTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountTextField.swift; sourceTree = "<group>"; };
+		34CFD053292280C0007CF0F0 /* RoundProfileImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoundProfileImage.swift; sourceTree = "<group>"; };
 		D8244536292244FC005EE8F1 /* UIFont+CustomFont.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIFont+CustomFont.swift"; sourceTree = "<group>"; };
 		D824453929224522005EE8F1 /* SFProDisplay-Regular.OTF */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SFProDisplay-Regular.OTF"; sourceTree = "<group>"; };
 		D824453A29224522005EE8F1 /* SFProDisplay-Semibold.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SFProDisplay-Semibold.ttf"; sourceTree = "<group>"; };
@@ -305,6 +307,7 @@
 				D8C5D8B22922879E003939CB /* ValidationButton.swift */,
 				34CFD053292280C0007CF0F0 /* RoundProfileImage.swift */,
 				CBA64FBE2922FC2A000FEEAD /* CountTextField.swift */,
+				34CFD053292280C0007CF0F0 /* RoundProfileImage.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";


### PR DESCRIPTION
### PR Type

- [x]  기능 추가 🔨
- [ ]  버그 수정 🐞
- [ ]  리팩토링 🚧
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [ ]  테스트 🔍
 

### Related Issue(작업 내용)
- resolve #31 
  - 프로필 이미지가 보이는 ImageView를 구현했습니다.

### 참고 사항
- init할 때 인자로 크기(Int)를 받습니다.
- setPhoto(image: UIImage)를 통해 이미지를 바꿉니다.
- 이 CustomView를 상속해서 오른쪽 아래에 +버튼, 언어이미지를 추가한 View를  또 파일로 만드는 것이 좋을까요?

### Screenshots(Optional)
<img src="https://user-images.githubusercontent.com/75964073/201690663-c479a741-8209-4025-b445-af5e0eed43f9.png" width="70%" height="70%">
