### PR TITLE
문자열의 개수를 보여주는 텍스트필드 구현

### DIFF
--- a/Mogakco/Mogakco.xcodeproj/project.pbxproj
+++ b/Mogakco/Mogakco.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		CBA64FFD292378FE000FEEAD /* SetPasswordViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBA64FFC292378FE000FEEAD /* SetPasswordViewController.swift */; };
 		CBA64FFF2923805D000FEEAD /* UILabel+LineSpacing.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBA64FFE2923805D000FEEAD /* UILabel+LineSpacing.swift */; };
 		CBA64FFB292364CA000FEEAD /* SetEmailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBA64FFA292364CA000FEEAD /* SetEmailViewController.swift */; };
+		CBA64FBF2922FC2A000FEEAD /* CountTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBA64FBE2922FC2A000FEEAD /* CountTextField.swift */; };
 		D8244537292244FC005EE8F1 /* UIFont+CustomFont.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8244536292244FC005EE8F1 /* UIFont+CustomFont.swift */; };
 		D824453B29224522005EE8F1 /* SFProDisplay-Regular.OTF in Resources */ = {isa = PBXBuildFile; fileRef = D824453929224522005EE8F1 /* SFProDisplay-Regular.OTF */; };
 		D824453C29224522005EE8F1 /* SFProDisplay-Semibold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = D824453A29224522005EE8F1 /* SFProDisplay-Semibold.ttf */; };
@@ -77,6 +78,7 @@
 		CBA64FFC292378FE000FEEAD /* SetPasswordViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetPasswordViewController.swift; sourceTree = "<group>"; };
 		CBA64FFE2923805D000FEEAD /* UILabel+LineSpacing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILabel+LineSpacing.swift"; sourceTree = "<group>"; };
 		CBA64FFA292364CA000FEEAD /* SetEmailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetEmailViewController.swift; sourceTree = "<group>"; };
+		CBA64FBE2922FC2A000FEEAD /* CountTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountTextField.swift; sourceTree = "<group>"; };
 		D8244536292244FC005EE8F1 /* UIFont+CustomFont.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIFont+CustomFont.swift"; sourceTree = "<group>"; };
 		D824453929224522005EE8F1 /* SFProDisplay-Regular.OTF */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SFProDisplay-Regular.OTF"; sourceTree = "<group>"; };
 		D824453A29224522005EE8F1 /* SFProDisplay-Semibold.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SFProDisplay-Semibold.ttf"; sourceTree = "<group>"; };
@@ -281,6 +283,7 @@
 				CB148FE6292254D6003E52FF /* MessageTextField.swift */,
 				D8C5D8B22922879E003939CB /* ValidationButton.swift */,
 				34CFD053292280C0007CF0F0 /* RoundProfileImage.swift */,
+				CBA64FBE2922FC2A000FEEAD /* CountTextField.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -582,6 +585,7 @@
 				D8C5D8B729228E87003939CB /* UIView+Shadow.swift in Sources */,
 				CBA64FFB292364CA000FEEAD /* SetEmailViewController.swift in Sources */,
 				D824455829224839005EE8F1 /* Identifiable.swift in Sources */,
+				CBA64FBF2922FC2A000FEEAD /* CountTextField.swift in Sources */,
 				D8244537292244FC005EE8F1 /* UIFont+CustomFont.swift in Sources */,
 				D824455329224839005EE8F1 /* ViewModel.swift in Sources */,
 				CB14900C292295F9003E52FF /* AppCoordinator.swift in Sources */,

--- a/Mogakco/Mogakco/Presentation/Common/View/CountTextField.swift
+++ b/Mogakco/Mogakco/Presentation/Common/View/CountTextField.swift
@@ -1,0 +1,124 @@
+//
+//  CountTextField.swift
+//  Mogakco
+//
+//  Created by 신소민 on 2022/11/15.
+//
+
+import UIKit
+
+import Then
+import SnapKit
+import RxCocoa
+import RxSwift
+
+final class CountTextField: UIView {
+    
+    // MARK: Public
+    
+    var validation: TextField.Validation = .none {
+        didSet {
+            textField.validation = validation
+        }
+    }
+    
+    var placeholder: String? {
+        didSet {
+            textField.placeholder = placeholder
+        }
+    }
+
+    var title: String? {
+        didSet {
+            titleLabel.text = title
+        }
+    }
+    
+    var maxCount: Int = -1 {
+        didSet {
+            update()
+        }
+    }
+    
+    // MARK: Private
+    
+    fileprivate let textField: TextField
+    
+    private let stackView = UIStackView().then {
+        $0.axis = .horizontal
+    }
+    
+    private let titleLabel = UILabel().then {
+        $0.font = UIFont(name: SFPro.bold.rawValue, size: 16)
+        $0.textAlignment = .left
+    }
+    
+    private let countLabel = UILabel().then {
+        $0.font = UIFont(name: SFPro.regular.rawValue, size: 14)
+        $0.textAlignment = .right
+    }
+    
+    private var disposable: Disposable?
+    
+    // MARK: Inits
+    
+    init(isSecure: Bool = false) {
+        textField = isSecure ? SecureTextField() : TextField()
+        super.init(frame: .zero)
+        layout()
+        bind()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: Methods
+    
+    private func bind() {
+        disposable = textField.rx.text
+            .subscribe { [weak self] _ in
+                self?.update()
+            }
+    }
+    
+    private func update() {
+        let maxCount = maxCount < 0 ? Int.max : maxCount
+        if let str = textField.text?.prefix(maxCount) {
+            textField.text = String(str)
+        }
+        countLabel.isHidden = maxCount == Int.max ? true : false
+        countLabel.text = "\(textField.text?.count ?? 0)/\(maxCount)"
+    }
+    
+    private func layout() {
+        layoutStackView()
+        layoutTextField()
+    }
+    
+    private func layoutStackView() {
+        [titleLabel, countLabel].forEach {
+            stackView.addArrangedSubview($0)
+        }
+        addSubview(stackView)
+        stackView.snp.makeConstraints { make in
+            make.top.equalToSuperview()
+            make.left.right.equalToSuperview().inset(4)
+        }
+    }
+    
+    private func layoutTextField() {
+        addSubview(textField)
+        textField.snp.makeConstraints { make in
+            make.bottom.left.right.equalToSuperview()
+            make.top.equalTo(stackView.snp.bottom).offset(15)
+        }
+    }
+}
+
+extension Reactive where Base: CountTextField {
+    
+    var text: ControlProperty<String?> {
+        return base.textField.rx.text
+    }
+}


### PR DESCRIPTION
### PR Type

- [X]  기능 추가 🔨
- [ ]  버그 수정 🐞
- [ ]  리팩토링 🚧
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [ ]  테스트 🔍
 

### Related Issue(작업 내용)

> 이슈 번호와 구현 내용 및 작업 했던 내역을 입력해주세요!
> 
- close #28
    - 입력된 문자열의 개수를 보여주는 텍스트필드를 만들었습니다. (CountTextField.swift)
    - 프로필이랑 스터디 생성화면에서 소개글을 입력받을 때는 높이가 긴 View를 사용하는데 텍스트필드의 길이를 늘리면
       placeholder가 중간에 나타나서 이 부분은 TextField 말고 TextView를 사용해야 할 것 같습니다. 우선은 텍스트필드를 사용해주세요!

### 참고 사항

#### CountTextField.swift

- maxCount의 초기값은 -1입니다. (-1: 무한대로 문자열을 입력할 수 있음)

- 문자열의 개수가 maxCount를 넘어가면 입력되지 않습니다.

```swift
private let textField = CountTextField().then {
    $0.placeholder = "입력입력"
    $0.title = "타이틀 나타남"
}
```

<img width="377" alt="스크린샷 2022-11-15 오전 7 59 27" src="https://user-images.githubusercontent.com/109145755/201785720-a1326579-b9d2-4ef5-9d68-e920bfc19550.png">

```swift
private let textField = CountTextField().then {
    $0.placeholder = "입력입력"
    $0.title = "타이틀 나타남"
    $0.maxCount = 20
}
```

<img width="382" alt="스크린샷 2022-11-15 오전 7 57 08" src="https://user-images.githubusercontent.com/109145755/201785398-11625fa9-3607-4383-b0c2-334035dbdbdf.png">

### Screenshots
https://user-images.githubusercontent.com/109145755/201786311-d285ef09-f1e1-436b-bb0e-6d67c3ad7e4d.mp4