### PR TITLE
RoundProfileImage 입력 인자 변경

### DIFF
--- a/Mogakco/Sources/Presentation/Common/View/RoundProfileImage.swift
+++ b/Mogakco/Sources/Presentation/Common/View/RoundProfileImage.swift
@@ -12,9 +12,9 @@ import Then
 
 final class RoundProfileImageView: UIImageView {
 
-    init(_ size: Int) {
+    init(_ length: Double) {
         super.init(frame: .zero)
-        layout(size)
+        layout(length)
     }
     
     required init?(coder: NSCoder) {
@@ -25,15 +25,15 @@ final class RoundProfileImageView: UIImageView {
         self.image = image
     }
     
-    private func layout(_ size: Int) {
+    private func layout(_ length: Double) {
         contentMode = .scaleAspectFill
         image = UIImage(systemName: "person")
         
         snp.makeConstraints {
-            $0.width.height.equalTo(size)
+            $0.width.height.equalTo(length)
         }
         
-        layer.cornerRadius = CGFloat(size/2)
+        layer.cornerRadius = length / 2
         layer.borderWidth = 1
         layer.borderColor = UIColor.mogakcoColor.backgroundSecondary?.cgColor
         clipsToBounds = true


### PR DESCRIPTION
### PR Type

- [ ]  기능 추가 🔨
- [ ]  버그 수정 🐞
- [x]  리팩토링 🚧
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [ ]  테스트 🔍
 

### Related Issue(작업 내용)

기존 RoundProfileImage의 입력 인자
-> size: Int

변경 후 RoundProfileImage의 입력 인자
-> length: Double

CGSize로 통용되는 size 변수와 헷갈리는 것 같아 변수명과 자료형을 변경하였습니다
Double로 사용한 이유는 CGSize의 width, height의 자료형을 기반으로 선택하였습니다.
