### PR TITLE
CountTextField 높이 layout 우선 순위 변경

### DIFF
--- a/Mogakco/Sources/Presentation/Common/View/CountTextField.swift
+++ b/Mogakco/Sources/Presentation/Common/View/CountTextField.swift
@@ -104,6 +104,7 @@ final class CountTextField: UIView {
         stackView.snp.makeConstraints { make in
             make.top.equalToSuperview()
             make.left.right.equalToSuperview().inset(4)
+            make.height.equalTo(52.0)
         }
     }
     
@@ -112,6 +113,7 @@ final class CountTextField: UIView {
         textField.snp.makeConstraints { make in
             make.bottom.left.right.equalToSuperview()
             make.top.equalTo(stackView.snp.bottom).offset(15)
+            make.height.greaterThanOrEqualTo(56.0)
         }
     }
 }


### PR DESCRIPTION
### PR Type

- [ ]  기능 추가 🔨
- [x]  버그 수정 🐞
- [ ]  리팩토링 🚧
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [ ]  테스트 🔍
 

### Related Issue(작업 내용)

CountTextField 레이아웃 설정 시 내부 라벨 스택뷰의 높이가 텍스트 필드의 높이보다 우선적으로 변경되어 레이아웃 설정을 수정하였습니다!
아래 스크린샷에서 소개 부분의 줄넘김 문제로 TextField 대신 TextView로 리팩토링이 필요해보입니다. @sominn9 

### Screenshots(Optional)
<img src="https://user-images.githubusercontent.com/73675540/202076875-10595c89-b35f-42f2-a012-205ef7f0f4f9.png" width="70%" height="70%">
