### PR TITLE
이메일 화면 로직 구현 및 바인딩

### DIFF
--- a/Mogakco/Sources/Presentation/Signup/ViewController/SetEmailViewController.swift
+++ b/Mogakco/Sources/Presentation/Signup/ViewController/SetEmailViewController.swift
@@ -155,7 +155,7 @@ final class SetEmailViewController: ViewController {
         view.addSubview(button)
         button.snp.makeConstraints {
             $0.left.right.equalToSuperview().inset(16)
-            $0.bottom.equalTo(view.safeAreaLayoutGuide).offset(-16)
+            $0.bottom.equalTo(view.safeAreaLayoutGuide)
             $0.height.equalTo(52)
         }
     }

--- a/Mogakco/Sources/Presentation/Signup/ViewController/SetEmailViewController.swift
+++ b/Mogakco/Sources/Presentation/Signup/ViewController/SetEmailViewController.swift
@@ -167,23 +167,25 @@ final class SetEmailViewController: ViewController {
     @objc func keyboardWillShow(_ notification: Notification) {
         if let userInfo = notification.userInfo,
            let keyboardFrame = userInfo[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect {
+            self.button.snp.remakeConstraints {
+                $0.height.equalTo(52)
+                $0.left.right.equalToSuperview().inset(16)
+                $0.bottom.equalTo(view.safeAreaLayoutGuide).offset(-keyboardFrame.height)
+            }
             UIView.animate(withDuration: 1) { [weak self] in
-                guard let self = self else { return }
-                self.button.snp.updateConstraints {
-                    $0.bottom.equalTo(self.view.safeAreaLayoutGuide).offset(-keyboardFrame.height)
-                }
-                self.view.layoutIfNeeded()
+                self?.view.layoutIfNeeded()
             }
         }
     }
     
     @objc func keyboardWillHide(_ notification: Notification) {
+        self.button.snp.remakeConstraints {
+            $0.height.equalTo(52)
+            $0.left.right.equalToSuperview().inset(16)
+            $0.bottom.equalTo(self.view.safeAreaLayoutGuide).offset(-16)
+        }
         UIView.animate(withDuration: 1) { [weak self] in
-            guard let self = self else { return }
-            self.button.snp.updateConstraints {
-                $0.bottom.equalTo(self.view.safeAreaLayoutGuide).offset(-16)
-            }
-            self.view.layoutIfNeeded()
+            self?.view.layoutIfNeeded()
         }
     }
 }

--- a/Mogakco/Sources/Presentation/Signup/ViewModel/SetEmailViewModel.swift
+++ b/Mogakco/Sources/Presentation/Signup/ViewModel/SetEmailViewModel.swift
@@ -26,7 +26,6 @@ final class SetEmailViewModel: ViewModel {
     }
 
     func transform(input: Input) -> Output {
-        let emailStorage = BehaviorSubject<String>(value: "")
         let textFieldState = PublishSubject<Bool>()
         let nextButtonEnabled = PublishSubject<Bool>()
         
@@ -34,7 +33,6 @@ final class SetEmailViewModel: ViewModel {
             .distinctUntilChanged()
             .subscribe { [weak self] text in
                 if let result = self?.validate(email: text) {
-                    emailStorage.onNext(text)
                     textFieldState.onNext(result)
                     nextButtonEnabled.onNext(result)
                 }
@@ -42,11 +40,10 @@ final class SetEmailViewModel: ViewModel {
             .disposed(by: disposeBag)
         
         input.nextButtonTapped
-            .subscribe { _ in
-                if let email = try? emailStorage.value() {
-                    // TODO: 비밀번호 화면으로 전환하기
-                    print("비밀번호 화면으로", email)
-                }
+            .withLatestFrom(input.email)
+            .subscribe { email in
+                // TODO: 비밀번호 화면으로 전환하기
+                print("비밀번호 화면으로", email)
             }
             .disposed(by: disposeBag)
         

--- a/Mogakco/Sources/Presentation/Signup/ViewModel/SetEmailViewModel.swift
+++ b/Mogakco/Sources/Presentation/Signup/ViewModel/SetEmailViewModel.swift
@@ -1,0 +1,64 @@
+//
+//  SetEmailViewModel.swift
+//  Mogakco
+//
+//  Created by 신소민 on 2022/11/16.
+//  Copyright © 2022 Mogakco. All rights reserved.
+//
+
+import Foundation
+
+import RxCocoa
+import RxSwift
+
+final class SetEmailViewModel: ViewModel {
+
+    var disposeBag = DisposeBag()
+    
+    struct Input {
+        let email: Observable<String>
+        let nextButtonTapped: Observable<Void>
+    }
+    
+    struct Output {
+        let textFieldState: PublishSubject<Bool>
+        let nextButtonEnabled: PublishSubject<Bool>
+    }
+
+    func transform(input: Input) -> Output {
+        let emailStorage = BehaviorSubject<String>(value: "")
+        let textFieldState = PublishSubject<Bool>()
+        let nextButtonEnabled = PublishSubject<Bool>()
+        
+        input.email
+            .distinctUntilChanged()
+            .subscribe { [weak self] text in
+                if let result = self?.validate(email: text) {
+                    emailStorage.onNext(text)
+                    textFieldState.onNext(result)
+                    nextButtonEnabled.onNext(result)
+                }
+            }
+            .disposed(by: disposeBag)
+        
+        input.nextButtonTapped
+            .subscribe { _ in
+                if let email = try? emailStorage.value() {
+                    // TODO: 비밀번호 화면으로 전환하기
+                    print("비밀번호 화면으로", email)
+                }
+            }
+            .disposed(by: disposeBag)
+        
+        return Output(
+            textFieldState: textFieldState,
+            nextButtonEnabled: nextButtonEnabled
+        )
+    }
+    
+    private func validate(email: String) -> Bool {
+        let regex = "[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,64}"
+        let predicate = NSPredicate(format: "SELF MATCHES %@", regex)
+        return predicate.evaluate(with: email)
+    }
+}


### PR DESCRIPTION
### PR Type

- [X]  기능 추가 🔨
- [ ]  버그 수정 🐞
- [ ]  리팩토링 🚧
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [ ]  테스트 🔍
 

### Related Issue(작업 내용)

> 이슈 번호와 구현 내용 및 작업 했던 내역을 입력해주세요!
> 
- close #62 
    - SetEmailViewModel을 만들었습니다.
    - SetEmailViewController와 ViewModel을 바인딩했습니다.

### 참고 사항
- 텍스트필드에 문자열을 입력할 때마다 유효성 검사를 하도록 구현했습니다.
- UseCase를 만들만큼 로직이 복잡하지 않아서 ViewModel만 구현했습니다.
- 버튼을 터치하면 이벤트가 두 번 전달되는데... 왜 이런지 아시는 분이 있다면 알려주세요!
<img width="304" alt="스크린샷 2022-11-16 오후 2 31 16" src="https://user-images.githubusercontent.com/109145755/202096461-774c8c03-52b1-4c2b-9ec7-29900e55a560.png">

### Screenshots
https://user-images.githubusercontent.com/109145755/202097059-f0802c03-667b-4846-9ce2-af61c65e9242.mp4

