### PR TITLE
프로필 생성 / 편집 화면 UI 구성 및 ViewModel 바인딩

### DIFF
--- a/Mogakco/Sources/Presentation/Common/View/CountTextField.swift
+++ b/Mogakco/Sources/Presentation/Common/View/CountTextField.swift
@@ -123,4 +123,8 @@ extension Reactive where Base: CountTextField {
     var text: ControlProperty<String?> {
         return base.textField.rx.text
     }
+    
+    func controlEvent(_ controlEvents: UIControl.Event) -> ControlEvent<()> {
+        return base.textField.rx.controlEvent(controlEvents)
+    }
 }

--- a/Mogakco/Sources/Presentation/Common/View/CountTextField.swift
+++ b/Mogakco/Sources/Presentation/Common/View/CountTextField.swift
@@ -123,8 +123,5 @@ extension Reactive where Base: CountTextField {
     var text: ControlProperty<String?> {
         return base.textField.rx.text
     }
-    
-    func controlEvent(_ controlEvents: UIControl.Event) -> ControlEvent<()> {
-        return base.textField.rx.controlEvent(controlEvents)
-    }
+
 }

--- a/Mogakco/Sources/Presentation/Profile/CreateProfile/ViewController/CreateProfileViewController.swift
+++ b/Mogakco/Sources/Presentation/Profile/CreateProfile/ViewController/CreateProfileViewController.swift
@@ -1,0 +1,144 @@
+//
+//  CreateProfileViewController.swift
+//  Mogakco
+//
+//  Created by 김범수 on 2022/11/16.
+//  Copyright © 2022 Mogakco. All rights reserved.
+//
+
+import UIKit
+
+final class CreateProfileViewController: ViewController {
+    
+    private let scrollView = UIScrollView().then {
+        $0.showsVerticalScrollIndicator = false
+        $0.bounces = true
+    }
+    
+    private let contentView = UIView()
+    
+    private let roundProfileImageView = RoundProfileImageView(120.0).then {
+        $0.snp.makeConstraints {
+            $0.size.equalTo(120.0)
+        }
+    }
+    
+    private let addImageButton = UIButton()
+    
+    private let nameCountTextField = CountTextField().then {
+        $0.title = "이름"
+        $0.maxCount = 10
+        $0.placeholder = "이름을 입력해주세요."
+    }
+    
+    private let introuceCountTextField = CountTextField().then {
+        $0.title = "소개"
+        $0.maxCount = 100
+        $0.placeholder = "자신을 소개해주세요."
+    }
+    
+    private let completeButton = ValidationButton().then {
+        $0.layer.cornerRadius = 8.0
+        $0.layer.masksToBounds = true
+        $0.setTitle("완료", for: .normal)
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configureUI()
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        navigationController?.navigationBar.isHidden = false
+        configureUI()
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        navigationController?.navigationBar.isHidden = true
+    }
+
+    func configureUI() {
+        configureNavigationBar()
+    }
+
+    override func layout() {
+        layoutScrollView()
+        layoutRoundProfileImageView()
+        layoutAddImageButton()
+        layoutNameCountTextField()
+        layoutIntrouceCountTextField()
+        layoutMarginView()
+        layoutNextButton()
+    }
+    
+    private func configureNavigationBar() {
+        navigationController?.navigationBar.topItem?.title = "프로필 생성"
+        
+    }
+    
+    private func layoutScrollView() {
+        view.addSubview(scrollView)
+        scrollView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+        
+        scrollView.addSubview(contentView)
+        contentView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+            $0.width.equalToSuperview()
+        }
+    }
+    
+    private func layoutRoundProfileImageView() {
+        contentView.addSubview(roundProfileImageView)
+        roundProfileImageView.snp.makeConstraints {
+            $0.centerX.equalToSuperview()
+            $0.top.equalToSuperview().inset(16.0)
+        }
+    }
+    
+    private func layoutAddImageButton() {
+        contentView.addSubview(addImageButton)
+        addImageButton.snp.makeConstraints {
+            $0.edges.equalTo(roundProfileImageView)
+        }
+    }
+    
+    private func layoutNameCountTextField() {
+        contentView.addSubview(nameCountTextField)
+        nameCountTextField.snp.makeConstraints {
+            $0.leading.trailing.equalToSuperview().inset(16.0)
+            $0.top.equalTo(roundProfileImageView.snp.bottom).offset(16.0)
+            $0.height.equalTo(120.0)
+        }
+    }
+    
+    private func layoutIntrouceCountTextField() {
+        contentView.addSubview(introuceCountTextField)
+        introuceCountTextField.snp.makeConstraints {
+            $0.leading.trailing.equalToSuperview().inset(16.0)
+            $0.top.equalTo(nameCountTextField.snp.bottom).offset(8.0)
+            $0.height.equalTo(240.0)
+        }
+    }
+    
+    private func layoutMarginView() {
+        let marginView = UIView()
+        contentView.addSubview(marginView)
+        marginView.snp.makeConstraints {
+            $0.leading.trailing.bottom.equalToSuperview()
+            $0.top.equalTo(introuceCountTextField.snp.bottom)
+        }
+    }
+    
+    private func layoutNextButton() {
+        view.addSubview(completeButton)
+        completeButton.snp.makeConstraints {
+            $0.leading.trailing.bottom.equalTo(view.safeAreaLayoutGuide).inset(16.0)
+            $0.height.equalTo(56.0)
+        }
+    }
+    
+}

--- a/Mogakco/Sources/Presentation/Profile/ViewController/CreateProfileViewController.swift
+++ b/Mogakco/Sources/Presentation/Profile/ViewController/CreateProfileViewController.swift
@@ -99,10 +99,10 @@ final class CreateProfileViewController: ViewController {
             .disposed(by: disposeBag)
         
         RxKeyboard.instance.visibleHeight
-          .drive(onNext: { keyboardVisibleHeight in
-              self.scrollView.contentInset.bottom = keyboardVisibleHeight
-          })
-          .disposed(by: disposeBag)
+            .drive(onNext: { keyboardVisibleHeight in
+                self.scrollView.contentInset.bottom = keyboardVisibleHeight
+            })
+            .disposed(by: disposeBag)
     }
     
     func configureUI() {

--- a/Mogakco/Sources/Presentation/Profile/ViewController/CreateProfileViewController.swift
+++ b/Mogakco/Sources/Presentation/Profile/ViewController/CreateProfileViewController.swift
@@ -10,6 +10,7 @@ import UIKit
 
 import RxCocoa
 import RxSwift
+import RxKeyboard
 
 final class CreateProfileViewController: ViewController {
     
@@ -63,6 +64,7 @@ final class CreateProfileViewController: ViewController {
         super.viewDidLoad()
         configureUI()
         configureImagePicker()
+        hideKeyboardWhenTappedAround()
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -95,6 +97,12 @@ final class CreateProfileViewController: ViewController {
         output.profileImage
             .drive(roundProfileImageView.rx.image)
             .disposed(by: disposeBag)
+        
+        RxKeyboard.instance.visibleHeight
+          .drive(onNext: { keyboardVisibleHeight in
+              self.scrollView.contentInset.bottom = keyboardVisibleHeight
+          })
+          .disposed(by: disposeBag)
     }
     
     func configureUI() {
@@ -195,7 +203,6 @@ private extension CreateProfileViewController {
 }
 
 // MARK: Picker Delegate
-// TODO: RxExtension
 
 extension CreateProfileViewController: UIImagePickerControllerDelegate, UINavigationControllerDelegate {
     func imagePickerController(_ picker: UIImagePickerController,

--- a/Mogakco/Sources/Presentation/Profile/ViewController/CreateProfileViewController.swift
+++ b/Mogakco/Sources/Presentation/Profile/ViewController/CreateProfileViewController.swift
@@ -46,8 +46,18 @@ final class CreateProfileViewController: ViewController {
         $0.setTitle("완료", for: .normal)
     }
     
+    private var viewModel: CreateProfiileViewModel
     private let imagePicker = UIImagePickerController()
-    private let selectedImage = PublishRelay<UIImage>()
+    private let selectedProfileImage = PublishRelay<UIImage>()
+    
+    init(viewModel: CreateProfiileViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -67,10 +77,23 @@ final class CreateProfileViewController: ViewController {
     }
     
     override func bind() {
+        let input = CreateProfiileViewModel.Input(
+            name: nameCountTextField.rx.text.orEmpty.asObservable(),
+            introduce: introuceCountTextField.rx.text.orEmpty.asObservable(),
+            selectedProfileImage: selectedProfileImage.asObservable(),
+            completeButtonTapped: completeButton.rx.tap.asObservable()
+        )
+        
+        let output = viewModel.transform(input: input)
+        
         addImageButton.rx.tap
             .subscribe(onNext: {
                 self.presentImagePicker()
             })
+            .disposed(by: disposeBag)
+        
+        output.profileImage
+            .drive(roundProfileImageView.rx.image)
             .disposed(by: disposeBag)
     }
     
@@ -186,7 +209,7 @@ extension CreateProfileViewController: UIImagePickerControllerDelegate, UINaviga
         }
         
         if let image = newImage {
-            selectedImage.accept(image)
+            selectedProfileImage.accept(image)
         }
         
         picker.dismiss(animated: true)

--- a/Mogakco/Sources/Presentation/Profile/ViewModel/CreateProfiileViewModel.swift
+++ b/Mogakco/Sources/Presentation/Profile/ViewModel/CreateProfiileViewModel.swift
@@ -1,0 +1,42 @@
+//
+//  CreateProfiileViewModel.swift
+//  Mogakco
+//
+//  Created by 김범수 on 2022/11/16.
+//  Copyright © 2022 Mogakco. All rights reserved.
+//
+
+import UIKit
+
+import RxCocoa
+import RxSwift
+
+final class CreateProfiileViewModel: ViewModel {
+    
+    struct Input {
+        let name: Observable<String>
+        let introduce: Observable<String>
+        let selectedProfileImage: Observable<UIImage>
+        let completeButtonTapped: Observable<Void>
+    }
+    
+    struct Output {
+        let profileImage: Driver<UIImage>
+    }
+    
+    var disposeBag = DisposeBag()
+    
+    func transform(input: Input) -> Output {
+        
+        input.completeButtonTapped
+            .withLatestFrom(Observable.combineLatest(input.name, input.introduce, input.selectedProfileImage))
+            .subscribe(onNext: { _ in
+                // TODO: UseCase - CreateProfile
+                // TODO: AppDelegate - Push
+            })
+            .disposed(by: disposeBag)
+        
+        return Output(profileImage: input.selectedProfileImage.asDriver(onErrorJustReturn: UIImage()))
+    }
+    
+}

--- a/Mogakco/Sources/Util/Extension/UIViewController+Keyboard.swift
+++ b/Mogakco/Sources/Util/Extension/UIViewController+Keyboard.swift
@@ -1,0 +1,21 @@
+//
+//  UIViewController+Keyboard.swift
+//  Mogakco
+//
+//  Created by 김범수 on 2022/11/16.
+//  Copyright © 2022 Mogakco. All rights reserved.
+//
+
+import UIKit
+
+extension UIViewController {
+    func hideKeyboardWhenTappedAround() {
+        let tap = UITapGestureRecognizer(target: self, action: #selector(dismissKeyboard))
+        tap.cancelsTouchesInView = false
+        view.addGestureRecognizer(tap)
+    }
+
+    @objc private func dismissKeyboard() {
+        view.endEditing(true)
+    }
+}


### PR DESCRIPTION
### PR Type

- [x]  기능 추가 🔨
- [ ]  버그 수정 🐞
- [ ]  리팩토링 🚧
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [ ]  테스트 🔍
 

### Related Issue(작업 내용)

- resolve #55 
    - 프로필 생성 / 편집 화면 UI 구성
    - 이미지 클릭 시 ImagePicker Present
    - ScrollView를 이용하여 아이폰 미니 대응
    - RxKeyboard를 이용해 키보드 대응
    - UIViewController Extension에 view 터치 시 keyboard resign 메소드 추가
    - ViewModel에 데이터 바인딩

### 참고 사항
현재는 CreateProfileViewController로 구현하였으나 추후 생성 / 편집 화면을 분리할지에 따라 클래스명 변경 or 추가 생성을 진행할 예정입니다.
RxKeyboard 설치 PR 이후 merge 예정입니다.

### Screenshots(Optional)

- 아이폰 14 Pro

https://user-images.githubusercontent.com/73675540/202121244-1010368c-8135-4f41-bda6-1f0378b287da.mp4

https://user-images.githubusercontent.com/73675540/202121299-ea5f898f-ff26-4ed0-a010-5f6d02b6ba4e.mp4


- 아이폰 SE

https://user-images.githubusercontent.com/73675540/202121296-5ec0b307-148a-4a8a-a132-4e9a12a24c62.mp4

https://user-images.githubusercontent.com/73675540/202121293-7220094c-2e43-46d4-a14c-b937cc378b6e.mp4


