### PR TITLE
오토레이아웃 이슈 해결

### DIFF
--- a/Mogakco/Sources/Presentation/Common/View/CountTextField.swift
+++ b/Mogakco/Sources/Presentation/Common/View/CountTextField.swift
@@ -104,7 +104,7 @@ final class CountTextField: UIView {
         stackView.snp.makeConstraints { make in
             make.top.equalToSuperview()
             make.left.right.equalToSuperview().inset(4)
-            make.height.equalTo(52.0)
+            make.height.equalTo(30.0)
         }
     }
     
@@ -112,8 +112,7 @@ final class CountTextField: UIView {
         addSubview(textField)
         textField.snp.makeConstraints { make in
             make.bottom.left.right.equalToSuperview()
-            make.top.equalTo(stackView.snp.bottom).offset(15)
-            make.height.greaterThanOrEqualTo(56.0)
+            make.top.equalTo(stackView.snp.bottom).offset(8)
         }
     }
 }

--- a/Mogakco/Sources/Presentation/Common/View/TextField.swift
+++ b/Mogakco/Sources/Presentation/Common/View/TextField.swift
@@ -64,7 +64,7 @@ class TextField: UITextField {
     
     private func layout() {
         snp.makeConstraints { make in
-            make.height.equalTo(56)
+            make.height.greaterThanOrEqualTo(Layout.textFieldHeight)
         }
     }
 }

--- a/Mogakco/Sources/Presentation/Common/View/ValidationButton.swift
+++ b/Mogakco/Sources/Presentation/Common/View/ValidationButton.swift
@@ -21,17 +21,10 @@ final class ValidationButton: UIButton {
     }
     
     private func configure() {
-        configureDefaultheight()
         configureFont()
         configureRadius()
         configureEnableColor()
         configureDisableColor()
-    }
-    
-    private func configureDefaultheight() {
-        snp.makeConstraints {
-            $0.height.equalTo(45)
-        }
     }
     
     private func configureFont() {

--- a/Mogakco/Sources/Presentation/Login/ViewController/LoginViewController.swift
+++ b/Mogakco/Sources/Presentation/Login/ViewController/LoginViewController.swift
@@ -109,7 +109,6 @@ final class LoginViewController: ViewController {
         loginButton.snp.makeConstraints {
             $0.left.right.equalToSuperview().inset(16)
             $0.top.equalTo(signupButton.snp.bottom).offset(32)
-            $0.height.equalTo(emailTextField.snp.height)
         }
     }
 }

--- a/Mogakco/Sources/Presentation/Login/ViewController/LoginViewController.swift
+++ b/Mogakco/Sources/Presentation/Login/ViewController/LoginViewController.swift
@@ -109,6 +109,7 @@ final class LoginViewController: ViewController {
         loginButton.snp.makeConstraints {
             $0.left.right.equalToSuperview().inset(16)
             $0.top.equalTo(signupButton.snp.bottom).offset(32)
+            $0.height.equalTo(Layout.buttonHeight)
         }
     }
 }

--- a/Mogakco/Sources/Presentation/Profile/ViewController/CreateProfileViewController.swift
+++ b/Mogakco/Sources/Presentation/Profile/ViewController/CreateProfileViewController.swift
@@ -163,6 +163,7 @@ final class CreateProfileViewController: ViewController {
         introuceCountTextField.snp.makeConstraints {
             $0.leading.trailing.equalToSuperview().inset(16.0)
             $0.top.equalTo(nameCountTextField.snp.bottom).offset(8.0)
+            $0.height.equalTo(240.0)
         }
     }
     
@@ -179,6 +180,7 @@ final class CreateProfileViewController: ViewController {
         view.addSubview(completeButton)
         completeButton.snp.makeConstraints {
             $0.leading.trailing.bottom.equalTo(view.safeAreaLayoutGuide).inset(16.0)
+            $0.height.equalTo(Layout.buttonHeight)
         }
     }
 }

--- a/Mogakco/Sources/Presentation/Profile/ViewController/CreateProfileViewController.swift
+++ b/Mogakco/Sources/Presentation/Profile/ViewController/CreateProfileViewController.swift
@@ -155,7 +155,6 @@ final class CreateProfileViewController: ViewController {
         nameCountTextField.snp.makeConstraints {
             $0.leading.trailing.equalToSuperview().inset(16.0)
             $0.top.equalTo(roundProfileImageView.snp.bottom).offset(16.0)
-            $0.height.equalTo(120.0)
         }
     }
     
@@ -164,7 +163,6 @@ final class CreateProfileViewController: ViewController {
         introuceCountTextField.snp.makeConstraints {
             $0.leading.trailing.equalToSuperview().inset(16.0)
             $0.top.equalTo(nameCountTextField.snp.bottom).offset(8.0)
-            $0.height.equalTo(240.0)
         }
     }
     
@@ -181,7 +179,6 @@ final class CreateProfileViewController: ViewController {
         view.addSubview(completeButton)
         completeButton.snp.makeConstraints {
             $0.leading.trailing.bottom.equalTo(view.safeAreaLayoutGuide).inset(16.0)
-            $0.height.equalTo(56.0)
         }
     }
 }

--- a/Mogakco/Sources/Presentation/Signup/ViewController/SetEmailViewController.swift
+++ b/Mogakco/Sources/Presentation/Signup/ViewController/SetEmailViewController.swift
@@ -153,7 +153,6 @@ final class SetEmailViewController: ViewController {
         button.snp.makeConstraints {
             $0.left.right.equalToSuperview().inset(16)
             $0.bottom.equalTo(view.safeAreaLayoutGuide)
-            $0.height.equalTo(52)
         }
     }
 }

--- a/Mogakco/Sources/Presentation/Signup/ViewController/SetEmailViewController.swift
+++ b/Mogakco/Sources/Presentation/Signup/ViewController/SetEmailViewController.swift
@@ -111,12 +111,7 @@ final class SetEmailViewController: ViewController {
         
         RxKeyboard.instance.visibleHeight
             .drive(onNext: { [weak self] keyboardVisibleHeight in
-                guard let self = self else { return }
-                self.button.snp.remakeConstraints {
-                    $0.height.equalTo(52)
-                    $0.left.right.equalToSuperview().inset(16)
-                    $0.bottom.equalTo(self.view.safeAreaLayoutGuide).offset(-keyboardVisibleHeight)
-                }
+                self?.updateButtonLayout(height: keyboardVisibleHeight)
             })
             .disposed(by: disposeBag)
     }
@@ -153,6 +148,15 @@ final class SetEmailViewController: ViewController {
         button.snp.makeConstraints {
             $0.left.right.equalToSuperview().inset(16)
             $0.bottom.equalTo(view.safeAreaLayoutGuide)
+            $0.height.equalTo(Layout.buttonHeight)
+        }
+    }
+    
+    private func updateButtonLayout(height: CGFloat) {
+        button.snp.makeConstraints {
+            $0.left.right.equalToSuperview().inset(16)
+            $0.bottom.equalTo(view.safeAreaLayoutGuide).offset(-height)
+            $0.height.equalTo(Layout.buttonHeight)
         }
     }
 }

--- a/Mogakco/Sources/Presentation/Signup/ViewController/SetPasswordViewController.swift
+++ b/Mogakco/Sources/Presentation/Signup/ViewController/SetPasswordViewController.swift
@@ -144,13 +144,11 @@ final class SetPasswordViewController: ViewController {
         button.snp.makeConstraints {
             $0.left.right.equalToSuperview().inset(16)
             $0.bottom.equalTo(view.safeAreaLayoutGuide)
-            $0.height.equalTo(52)
         }
     }
     
     private func updateButtonLayout(height: CGFloat) {
-        button.snp.remakeConstraints {
-            $0.height.equalTo(52)
+        button.snp.makeConstraints {
             $0.left.right.equalToSuperview().inset(16)
             $0.bottom.equalTo(view.safeAreaLayoutGuide).offset(-height)
         }

--- a/Mogakco/Sources/Presentation/Signup/ViewController/SetPasswordViewController.swift
+++ b/Mogakco/Sources/Presentation/Signup/ViewController/SetPasswordViewController.swift
@@ -151,6 +151,7 @@ final class SetPasswordViewController: ViewController {
         button.snp.makeConstraints {
             $0.left.right.equalToSuperview().inset(16)
             $0.bottom.equalTo(view.safeAreaLayoutGuide).offset(-height)
+            $0.height.equalTo(Layout.buttonHeight)
         }
     }
 }

--- a/Mogakco/Sources/Util/Constant/Layout.swift
+++ b/Mogakco/Sources/Util/Constant/Layout.swift
@@ -1,0 +1,14 @@
+//
+//  Layout.swift
+//  Mogakco
+//
+//  Created by 신소민 on 2022/11/18.
+//  Copyright © 2022 Mogakco. All rights reserved.
+//
+
+import Foundation
+
+enum Layout {
+    static let buttonHeight: CGFloat = 52
+    static let textFieldHeight: CGFloat = 56
+}


### PR DESCRIPTION
### PR Type

- [ ]  기능 추가 🔨
- [X]  버그 수정 🐞
- [ ]  리팩토링 🚧
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [ ]  테스트 🔍
 

### Related Issue(작업 내용)

- 오토레이아웃 이슈를 해결했습니다.

  - ~버튼과 텍스트필드에 Height Constraint가 설정되어 있는데 뷰 컨트롤러에서 다시 설정해서 나는 오류였습니다.~

  - -> 버튼과 텍스트필드에 Height Constraint를 설정할 수 있도록 리팩토링을 진행했습니다.

-----------------------------------

### 최종 변경사항

#### 1. Constant

레이아웃 설정은 여러 뷰 컨트롤러에서 사용되기 때문에 Util > Constant 폴더에 Layout 파일을 만들고 상수를 선언했습니다.

```swift
enum Layout {
    static let buttonHeight: CGFloat = 52
    static let textFieldHeight: CGFloat = 56
}
```

#### 2. 버튼

ValidationButton은 뷰 컨트롤러에서 Height을 지정해줘야 합니다.
```swift
button.snp.makeConstraints {
   ...
   $0.height.equalTo(Layout.buttonHeight)
}
```
| Height 설정 안했을 때 | Height을 설정했을 때 |
|---|---|
|<img width="378" alt="스크린샷 2022-11-18 오후 4 23 42" src="https://user-images.githubusercontent.com/109145755/202644817-2ffa7199-800f-4182-8227-ad5419e94129.png">|<img width="385" alt="스크린샷 2022-11-18 오후 4 23 04" src="https://user-images.githubusercontent.com/109145755/202644680-6de4d789-4fbe-47bc-b04b-45383079c89c.png">|

#### 3. 텍스트필드

CountTextField, MessageTextField 등이 내부에 커스텀 TextField를 가지고 있기 때문에 어쩔 수 없이 커스텀 TextField에는 Height을 greaterThanOrEqualTo로 설정했습니다. 그래서 CountTextField, MessageTextField, TextField를 사용할 때는 높이를 설정해주지 않아도 됩니다. 그러나 TextField의 Height이 greaterThanOrEqualTo로 설정되어 있기 때문에 높이를 56보다 크게 자유자재로 설정하는 것이 가능합니다.

| Height 설정 안했을 때 | Height을 240으로 설정했을 때 |
|---|---|
|<img width="378" alt="스크린샷 2022-11-18 오후 4 31 50" src="https://user-images.githubusercontent.com/109145755/202646299-3af3cacf-2ecd-4f30-8091-2db9bc8b5a03.png">|<img width="370" alt="스크린샷 2022-11-18 오후 4 32 12" src="https://user-images.githubusercontent.com/109145755/202646362-f8b89459-5b98-40bd-abcd-7ac1c3215fcc.png">|
