### PR TITLE
Hashtag api 구현 

### DIFF
--- a/Mogakco/Sources/Data/DataMapping/Career.swift
+++ b/Mogakco/Sources/Data/DataMapping/Career.swift
@@ -1,0 +1,33 @@
+//
+//  Career.swift
+//  Mogakco
+//
+//  Created by 이주훈 on 2022/11/21.
+//  Copyright © 2022 Mogakco. All rights reserved.
+//
+
+import Foundation
+
+enum Career: String, CaseIterable, Hashtag {
+    case baemin
+    case carrot
+    case facebook
+    case kakao
+    case line
+    case naver
+    case toss
+    case worksMobile
+    
+    func hashtagTitle() -> String {
+        switch self {
+        case .baemin: return "배달의민족"
+        case .carrot: return "당근마켓"
+        case .facebook: return "페이스북(메타)"
+        case .kakao: return "카카오"
+        case .line: return "라인"
+        case .naver: return "네이버"
+        case .toss: return "토스"
+        case .worksMobile: return "웍스모바일"
+        }
+    }
+}

--- a/Mogakco/Sources/Data/DataMapping/Category.swift
+++ b/Mogakco/Sources/Data/DataMapping/Category.swift
@@ -1,0 +1,41 @@
+//
+//  Category.swift
+//  Mogakco
+//
+//  Created by 이주훈 on 2022/11/21.
+//  Copyright © 2022 Mogakco. All rights reserved.
+//
+
+import Foundation
+
+enum Category: String, CaseIterable, Hashtag {
+    case artificialIntelligence = "ai"
+    case algorithm
+    case android
+    case backend
+    case bigdata
+    case contest
+    case computerScience = "cs"
+    case frontend
+    case hackathon
+    case iOS = "ios"
+    case interview
+    case machineLearning
+    
+    func hashtagTitle() -> String {
+        switch self {
+        case .artificialIntelligence: return "AI"
+        case .algorithm: return "알고리즘"
+        case .android: return "안드로이드"
+        case .backend: return "백엔드"
+        case .bigdata: return "빅데이터"
+        case .contest: return "공모전"
+        case .computerScience: return "CS"
+        case .frontend: return "프론트엔드"
+        case .hackathon: return "해커톤"
+        case .iOS: return "iOS"
+        case .interview: return "인터뷰"
+        case .machineLearning: return "머신러닝"
+        }
+    }
+}

--- a/Mogakco/Sources/Data/DataMapping/Languages.swift
+++ b/Mogakco/Sources/Data/DataMapping/Languages.swift
@@ -8,7 +8,11 @@
 
 import Foundation
 
-enum Languages: String, CaseIterable {
+protocol Hashtag {
+    func hashtagTitle() -> String
+}
+
+enum Languages: String, CaseIterable, Hashtag {
     case cLang = "c"
     case cShop
     case cpp

--- a/Mogakco/Sources/Data/DataMapping/Languages.swift
+++ b/Mogakco/Sources/Data/DataMapping/Languages.swift
@@ -1,0 +1,62 @@
+//
+//  LanguageResponseDTO.swift
+//  Mogakco
+//
+//  Created by 이주훈 on 2022/11/21.
+//  Copyright © 2022 Mogakco. All rights reserved.
+//
+
+import Foundation
+
+enum Languages: String, CaseIterable {
+    case cLang = "c"
+    case cShop
+    case cpp
+    case dart
+    case goLang = "go"
+    case haskell
+    case javaScript
+    case kotlin
+    case matlab
+    case objectC
+    case php
+    case python
+    case rLang = "r" // Lint 3자 제한 때문
+    case ruby
+    case rust
+    case scratch
+    case swift
+    case visualBasic
+    
+    static func allNames() -> [String] {
+        var names: [String] = []
+        self.allCases.forEach {
+            names.append($0.rawValue)
+        }
+        
+        return names
+    }
+    
+    func hashtagTitle() -> String {
+        switch self {
+        case .cLang: return "C"
+        case .cShop: return "C#"
+        case .cpp: return "C++"
+        case .dart: return "Dart"
+        case .goLang: return "Go"
+        case .haskell: return "Haskell"
+        case .javaScript: return "JavaScript"
+        case .kotlin: return "Kotlin"
+        case .matlab: return "Matlab"
+        case .objectC: return "Objective-C"
+        case .php: return "PHP"
+        case .python: return "Python"
+        case .rLang: return "R"
+        case .ruby: return "Ruby"
+        case .rust: return "Rust"
+        case .scratch: return "Scratch"
+        case .swift: return "Swift"
+        case .visualBasic: return "Visual Basic"
+        }
+    }
+}

--- a/Mogakco/Sources/Data/DataSources/Local/HashtagDataSource.swift
+++ b/Mogakco/Sources/Data/DataSources/Local/HashtagDataSource.swift
@@ -34,7 +34,7 @@ struct HashtagDataSource: HashtagDataSourceProtocol {
         case dart
         case goLang = "go"
         case haskell
-        case javaStript
+        case javaScript
         case kotlin
         case matlab
         case objectC

--- a/Mogakco/Sources/Data/DataSources/Local/HashtagDataSource.swift
+++ b/Mogakco/Sources/Data/DataSources/Local/HashtagDataSource.swift
@@ -11,7 +11,7 @@ import Foundation
 import RxSwift
 
 struct HashtagDataSource: HashtagDataSourceProtocol {
-    func loadTagList(kind: KindHashtag) -> Observable<[String]> {
+    func loadTagList(kind: KindHashtag) -> Observable<[Languages]> {
         return Observable.create { emitter in
             switch kind {
             case .language: emitter.onNext(loadLanguage())
@@ -23,37 +23,7 @@ struct HashtagDataSource: HashtagDataSourceProtocol {
         }
     }
     
-    private func loadLanguage() -> [String] {
-        return Languages.allNames()
-    }
-    
-    enum Languages: String, CaseIterable {
-        case cLang = "c"
-        case cShop
-        case cpp
-        case dart
-        case goLang = "go"
-        case haskell
-        case javaScript
-        case kotlin
-        case matlab
-        case objectC
-        case php
-        case python
-        case rLang = "r" // Lint 3자 제한 때문
-        case ruby
-        case rust
-        case scratch
-        case swift
-        case visualBasic
-        
-        static func allNames() -> [String] {
-            var names: [String] = []
-            self.allCases.forEach {
-                names.append($0.rawValue)
-            }
-            
-            return names
-        }
+    private func loadLanguage() -> [Languages] {
+        return Languages.allCases
     }
 }

--- a/Mogakco/Sources/Data/DataSources/Local/HashtagDataSource.swift
+++ b/Mogakco/Sources/Data/DataSources/Local/HashtagDataSource.swift
@@ -8,10 +8,52 @@
 
 import Foundation
 
+import RxSwift
+
 struct HashtagDataSource: HashtagDataSourceProtocol {
-    func loadTagList(kind: KindHashtag) -> [String] {
-        // TODO: - 종류별로 리턴
+    func loadTagList(kind: KindHashtag) -> Observable<[String]> {
+        return Observable.create { emitter in
+            switch kind {
+            case .language: emitter.onNext(loadLanguage())
+            case .career: break
+            case .category: break
+            }
+            
+            return Disposables.create()
+        }
+    }
+    
+    private func loadLanguage() -> [String] {
+        return Languages.allNames()
+    }
+    
+    enum Languages: String, CaseIterable {
+        case cLang = "c"
+        case cShop
+        case cpp
+        case dart
+        case goLang = "go"
+        case haskell
+        case javaStript
+        case kotlin
+        case matlab
+        case objectC
+        case php
+        case python
+        case rLang = "r" // Lint 3자 제한 때문
+        case ruby
+        case rust
+        case scratch
+        case swift
+        case visualBasic
         
-        return []
+        static func allNames() -> [String] {
+            var names: [String] = []
+            self.allCases.forEach {
+                names.append($0.rawValue)
+            }
+            
+            return names
+        }
     }
 }

--- a/Mogakco/Sources/Data/DataSources/Protocol/HashtagDataSourceProtocol.swift
+++ b/Mogakco/Sources/Data/DataSources/Protocol/HashtagDataSourceProtocol.swift
@@ -8,6 +8,8 @@
 
 import Foundation
 
+import RxSwift
+
 protocol HashtagDataSourceProtocol {
-    func loadTagList(kind: KindHashtag) -> [String]
+    func loadTagList(kind: KindHashtag) -> Observable<[String]>
 }

--- a/Mogakco/Sources/Data/DataSources/Protocol/HashtagDataSourceProtocol.swift
+++ b/Mogakco/Sources/Data/DataSources/Protocol/HashtagDataSourceProtocol.swift
@@ -11,5 +11,5 @@ import Foundation
 import RxSwift
 
 protocol HashtagDataSourceProtocol {
-    func loadTagList(kind: KindHashtag) -> Observable<[String]>
+    func loadTagList(kind: KindHashtag) -> Observable<[Languages]>
 }

--- a/Mogakco/Sources/Data/Repositories/HashtagRepository.swift
+++ b/Mogakco/Sources/Data/Repositories/HashtagRepository.swift
@@ -18,7 +18,7 @@ struct HashtagRepository: HashtagRepositoryProtocol {
         self.localHashtagDataSource = localHashtagDataSource
     }
     
-    func loadTagList(kind: KindHashtag) -> Observable<[String]> {
+    func loadTagList(kind: KindHashtag) -> Observable<[Languages]> {
         return localHashtagDataSource.loadTagList(kind: kind)
     }
 }

--- a/Mogakco/Sources/Data/Repositories/HashtagRepository.swift
+++ b/Mogakco/Sources/Data/Repositories/HashtagRepository.swift
@@ -8,12 +8,17 @@
 
 import Foundation
 
+import RxSwift
+
 struct HashtagRepository: HashtagRepositoryProtocol {
     
     let localHashtagDataSource: HashtagDataSourceProtocol
     
-    func loadTagList(kind: KindHashtag) -> [String] {
-        let tagList = localHashtagDataSource.loadTagList(kind: kind)
-        return tagList
+    init(localHashtagDataSource: HashtagDataSourceProtocol) {
+        self.localHashtagDataSource = localHashtagDataSource
+    }
+    
+    func loadTagList(kind: KindHashtag) -> Observable<[String]> {
+        return localHashtagDataSource.loadTagList(kind: kind)
     }
 }

--- a/Mogakco/Sources/Domain/Repositories/HashtagRepositoryProtocol.swift
+++ b/Mogakco/Sources/Domain/Repositories/HashtagRepositoryProtocol.swift
@@ -11,5 +11,5 @@ import Foundation
 import RxSwift
 
 protocol HashtagRepositoryProtocol {
-    func loadTagList(kind: KindHashtag) -> Observable<[String]>
+    func loadTagList(kind: KindHashtag) -> Observable<[Languages]>
 }

--- a/Mogakco/Sources/Domain/UseCases/HashtagUseCase.swift
+++ b/Mogakco/Sources/Domain/UseCases/HashtagUseCase.swift
@@ -10,7 +10,7 @@ import Foundation
 
 import RxSwift
 
-struct HashtagUsecase: HashtagUsecaseProtocol {
+struct HashtagUsecase: HashtagUseCaseProtocol {
     
     let hashtagRepository: HashtagRepositoryProtocol
     

--- a/Mogakco/Sources/Domain/UseCases/HashtagUseCase.swift
+++ b/Mogakco/Sources/Domain/UseCases/HashtagUseCase.swift
@@ -18,7 +18,7 @@ struct HashtagUsecase: HashtagUseCaseProtocol {
         self.hashtagRepository = hashtagRepository
     }
     
-    func loadTagList(kind: KindHashtag) -> Observable<[String]> {
+    func loadTagList(kind: KindHashtag) -> Observable<[Languages]> {
         return hashtagRepository.loadTagList(kind: kind)
     }
 }

--- a/Mogakco/Sources/Domain/UseCases/HashtagUseCase.swift
+++ b/Mogakco/Sources/Domain/UseCases/HashtagUseCase.swift
@@ -8,8 +8,17 @@
 
 import Foundation
 
-protocol HashtagUseCaseProtocol {
-}
+import RxSwift
 
-struct HashtagUseCase {
+struct HashtagUsecase: HashtagUsecaseProtocol {
+    
+    let hashtagRepository: HashtagRepositoryProtocol
+    
+    init(hashtagRepository: HashtagRepositoryProtocol) {
+        self.hashtagRepository = hashtagRepository
+    }
+    
+    func loadTagList(kind: KindHashtag) -> Observable<[String]> {
+        return hashtagRepository.loadTagList(kind: kind)
+    }
 }

--- a/Mogakco/Sources/Domain/UseCases/Protocol/HashtagUseCaseProtocol.swift
+++ b/Mogakco/Sources/Domain/UseCases/Protocol/HashtagUseCaseProtocol.swift
@@ -10,6 +10,6 @@ import Foundation
 
 import RxSwift
 
-protocol HashtagUsecaseProtocol {
+protocol HashtagUseCaseProtocol {
     func loadTagList(kind: KindHashtag) -> Observable<[String]>
 }

--- a/Mogakco/Sources/Domain/UseCases/Protocol/HashtagUseCaseProtocol.swift
+++ b/Mogakco/Sources/Domain/UseCases/Protocol/HashtagUseCaseProtocol.swift
@@ -11,5 +11,5 @@ import Foundation
 import RxSwift
 
 protocol HashtagUseCaseProtocol {
-    func loadTagList(kind: KindHashtag) -> Observable<[String]>
+    func loadTagList(kind: KindHashtag) -> Observable<[Languages]>
 }

--- a/Mogakco/Sources/Domain/Usecase/Hashtag/Protocol/HashtagUsecaseProtocol.swift
+++ b/Mogakco/Sources/Domain/Usecase/Hashtag/Protocol/HashtagUsecaseProtocol.swift
@@ -1,5 +1,5 @@
 //
-//  HashtagRepositoryProtocol.swift
+//  HashtagUsecaseProtocol.swift
 //  Mogakco
 //
 //  Created by 이주훈 on 2022/11/17.
@@ -10,6 +10,6 @@ import Foundation
 
 import RxSwift
 
-protocol HashtagRepositoryProtocol {
+protocol HashtagUsecaseProtocol {
     func loadTagList(kind: KindHashtag) -> Observable<[String]>
 }

--- a/Mogakco/Sources/Presentation/Common/Coordinator/AdditionalSignupCoordinator.swift
+++ b/Mogakco/Sources/Presentation/Common/Coordinator/AdditionalSignupCoordinator.swift
@@ -35,15 +35,19 @@ final class AdditionalSignupCoordinator: Coordinator, AdditionalSignupCoordinato
     }
     
     func showLanguage() {
-        let viewModel = HashtagSelectViewModel()
-        viewModel.coordinator = self
+        let hashtagDataSource = HashtagDataSource()
+        let hashtagRepository = HashtagRepository(localHashtagDataSource: hashtagDataSource)
+        let hashtagUsecase = HashtagUsecase(hashtagRepository: hashtagRepository)
+        let viewModel = HashtagSelectViewModel(coordinator: self, hashTagUsecase: hashtagUsecase)
         let hashtagSelectViewController = HashtagSelectViewController(kind: .language, viewModel: viewModel)
         navigationController.pushViewController(hashtagSelectViewController, animated: true)
     }
     
     func showCareer() {
-        let viewModel = HashtagSelectViewModel()
-        viewModel.coordinator = self
+        let hashtagDataSource = HashtagDataSource()
+        let hashtagRepository = HashtagRepository(localHashtagDataSource: hashtagDataSource)
+        let hashtagUsecase = HashtagUsecase(hashtagRepository: hashtagRepository)
+        let viewModel = HashtagSelectViewModel(coordinator: self, hashTagUsecase: hashtagUsecase)
         let hashtagSelectViewController = HashtagSelectViewController(kind: .career, viewModel: viewModel)
         navigationController.pushViewController(hashtagSelectViewController, animated: true)
     }

--- a/Mogakco/Sources/Presentation/Common/View/BadgeCell.swift
+++ b/Mogakco/Sources/Presentation/Common/View/BadgeCell.swift
@@ -72,7 +72,7 @@ final class BadgeCell: UICollectionViewCell, Identifiable {
     }
     
     func setInfo(iconName: String?, title: String?) {
-        iconimageView.image = UIImage(named: iconName ?? "" ) ?? UIImage(systemName: "questionmark.app")
+        iconimageView.image = UIImage(named: iconName ?? "Default" ) ?? UIImage(systemName: "questionmark.app")
         titleLabel.text = title ?? "??"
     }
     

--- a/Mogakco/Sources/Presentation/HashtagSelect/ViewController/HashtagSelectViewController.swift
+++ b/Mogakco/Sources/Presentation/HashtagSelect/ViewController/HashtagSelectViewController.swift
@@ -41,7 +41,7 @@ final class HashtagSelectViewController: ViewController {
     
     // MARK: - Property
     
-    var viewModel: HashtagSelectViewModel
+    let viewModel: HashtagSelectViewModel
     
     // MARK: - function
     

--- a/Mogakco/Sources/Presentation/HashtagSelect/ViewController/HashtagSelectViewController.swift
+++ b/Mogakco/Sources/Presentation/HashtagSelect/ViewController/HashtagSelectViewController.swift
@@ -42,10 +42,12 @@ final class HashtagSelectViewController: ViewController {
     // MARK: - Property
     
     let viewModel: HashtagSelectViewModel
+    let kind: KindHashtag
     
     // MARK: - function
     
     init(kind: KindHashtag, viewModel: HashtagSelectViewModel) {
+        self.kind = kind
         self.viewModel = viewModel
         super.init(nibName: nil, bundle: nil)
     }
@@ -74,6 +76,7 @@ final class HashtagSelectViewController: ViewController {
     
     override func bind() {
         let input = HashtagSelectViewModel.Input(
+            kindHashtag: Observable.just(kind),
             nextButtonTapped: nextButton.rx.tap.asObservable()
         )
         let output = viewModel.transform(input: input)

--- a/Mogakco/Sources/Presentation/HashtagSelect/ViewController/HashtagSelectViewController.swift
+++ b/Mogakco/Sources/Presentation/HashtagSelect/ViewController/HashtagSelectViewController.swift
@@ -117,6 +117,7 @@ final class HashtagSelectViewController: ViewController {
         nextButton.snp.makeConstraints {
             $0.leading.trailing.equalToSuperview().inset(16)
             $0.bottom.equalTo(view.safeAreaLayoutGuide)
+            $0.height.equalTo(Layout.buttonHeight)
         }
     }
 }

--- a/Mogakco/Sources/Presentation/HashtagSelect/ViewController/HashtagSelectViewController.swift
+++ b/Mogakco/Sources/Presentation/HashtagSelect/ViewController/HashtagSelectViewController.swift
@@ -140,11 +140,11 @@ extension HashtagSelectViewController: UICollectionViewDataSource {
         
         cell.prepareForReuse()
         
-        let cellTitle = try? viewModel.badgeList.value()[indexPath.row]
-        if viewModel.isSelected(title: cellTitle) {
+        let cellInfo = try? viewModel.badgeList.value()[indexPath.row]
+        if viewModel.isSelected(title: cellInfo?.rawValue) {
             cell.select()
         }
-        cell.setInfo(iconName: cellTitle, title: cellTitle)
+        cell.setInfo(iconName: cellInfo?.rawValue, title: cellInfo?.hashtagTitle())
         
         return cell
     }
@@ -176,7 +176,9 @@ extension HashtagSelectViewController: UICollectionViewDelegateFlowLayout {
         layout collectionViewLayout: UICollectionViewLayout,
         sizeForItemAt indexPath: IndexPath
     ) -> CGSize {
-        let title = viewModel.cellTitle(index: indexPath.row)
+        guard let title = viewModel.cellTitle(index: indexPath.row)?.hashtagTitle() else {
+            return CGSize(width: BadgeCell.addWidth, height: BadgeCell.height)
+        }
         
         return CGSize(
             width: title.size(

--- a/Mogakco/Sources/Presentation/HashtagSelect/ViewModel/HashtagSelectViewModel.swift
+++ b/Mogakco/Sources/Presentation/HashtagSelect/ViewModel/HashtagSelectViewModel.swift
@@ -30,13 +30,16 @@ final class HashtagSelectViewModel: ViewModel {
     var disposeBag = DisposeBag()
     var selectedBadges: [String] = []
     let badgeList = BehaviorSubject<[String]>(value: [])
+    let hashTagUsecase: HashtagUsecaseProtocol
     
     var collectionViewCount: Int {
         guard let count = try? badgeList.value().count else { return 0 }
         return count
     }
     
-    init() {
+    init(coordinator: AdditionalSignupCoordinatorProtocol, hashTagUsecase: HashtagUsecaseProtocol) {
+        self.coordinator = coordinator
+        self.hashTagUsecase = hashTagUsecase
     }
     
     func transform(input: Input) -> Output {

--- a/Mogakco/Sources/Presentation/HashtagSelect/ViewModel/HashtagSelectViewModel.swift
+++ b/Mogakco/Sources/Presentation/HashtagSelect/ViewModel/HashtagSelectViewModel.swift
@@ -28,7 +28,7 @@ final class HashtagSelectViewModel: ViewModel {
     }
     
     weak var coordinator: AdditionalSignupCoordinatorProtocol?
-    let hashTagUsecase: HashtagUsecaseProtocol
+    let hashTagUsecase: HashtagUseCaseProtocol
     var disposeBag = DisposeBag()
     var selectedBadges: [String] = []
     let badgeList = BehaviorSubject<[String]>(value: [])
@@ -38,7 +38,7 @@ final class HashtagSelectViewModel: ViewModel {
         return count
     }
     
-    init(coordinator: AdditionalSignupCoordinatorProtocol, hashTagUsecase: HashtagUsecaseProtocol) {
+    init(coordinator: AdditionalSignupCoordinatorProtocol, hashTagUsecase: HashtagUseCaseProtocol) {
         self.coordinator = coordinator
         self.hashTagUsecase = hashTagUsecase
     }

--- a/Mogakco/Sources/Presentation/HashtagSelect/ViewModel/HashtagSelectViewModel.swift
+++ b/Mogakco/Sources/Presentation/HashtagSelect/ViewModel/HashtagSelectViewModel.swift
@@ -82,11 +82,6 @@ final class HashtagSelectViewModel: ViewModel {
     }
     
     func isSelected(title: String?) -> Bool {
-//        guard let selected = try? selectedBadges.value(),
-//              let title else {
-//            return false
-//        }
-        
         if let title {
             if selectedBadges.contains(title) { return true }
         }
@@ -95,11 +90,6 @@ final class HashtagSelectViewModel: ViewModel {
     }
     
     func selectBadge(title: String) {
-//        guard var selected = try? selectedBadges.value(),
-//              !selected.contains(title) else {
-//            return
-//        }
-        
         if !selectedBadges.contains(title) {
             selectedBadges.append(title)
             return
@@ -107,11 +97,6 @@ final class HashtagSelectViewModel: ViewModel {
     }
     
     func deselectBadge(title: String) {
-//        guard var selected = try? selectedBadges.value(),
-//              let removeIndex = selected.firstIndex(of: title) else {
-//            return
-//        }
-        
         guard selectedBadges.contains(title),
               let removeIndex = selectedBadges.firstIndex(of: title) else {
             return

--- a/Mogakco/Sources/Presentation/HashtagSelect/ViewModel/HashtagSelectViewModel.swift
+++ b/Mogakco/Sources/Presentation/HashtagSelect/ViewModel/HashtagSelectViewModel.swift
@@ -31,7 +31,7 @@ final class HashtagSelectViewModel: ViewModel {
     let hashTagUsecase: HashtagUseCaseProtocol
     var disposeBag = DisposeBag()
     var selectedBadges: [String] = []
-    let badgeList = BehaviorSubject<[String]>(value: [])
+    let badgeList = BehaviorSubject<[Languages]>(value: [])
     
     var collectionViewCount: Int {
         guard let count = try? badgeList.value().count else { return 0 }
@@ -76,8 +76,8 @@ final class HashtagSelectViewModel: ViewModel {
             .disposed(by: disposeBag)
     }
     
-    func cellTitle(index: Int) -> String {
-        guard let list = try? badgeList.value() else { return "?" }
+    func cellTitle(index: Int) -> Languages? {
+        guard let list = try? badgeList.value() else { return nil }
         return list[index]
     }
     

--- a/Mogakco/Sources/Presentation/HashtagSelect/ViewModel/HashtagSelectViewModel.swift
+++ b/Mogakco/Sources/Presentation/HashtagSelect/ViewModel/HashtagSelectViewModel.swift
@@ -28,7 +28,7 @@ final class HashtagSelectViewModel: ViewModel {
     
     weak var coordinator: AdditionalSignupCoordinatorProtocol?
     var disposeBag = DisposeBag()
-    let selectedBadges = BehaviorSubject<[String]>(value: [])
+    var selectedBadges: [String] = []
     let badgeList = BehaviorSubject<[String]>(value: [])
     
     var collectionViewCount: Int {
@@ -63,32 +63,41 @@ final class HashtagSelectViewModel: ViewModel {
     }
     
     func isSelected(title: String?) -> Bool {
-        guard let selected = try? selectedBadges.value(),
-              let title else {
-            return false
+//        guard let selected = try? selectedBadges.value(),
+//              let title else {
+//            return false
+//        }
+        
+        if let title {
+            if selectedBadges.contains(title) { return true }
         }
-        if selected.contains(title) { return true }
         
         return false
     }
     
     func selectBadge(title: String) {
-        guard var selected = try? selectedBadges.value(),
-              !selected.contains(title) else {
+//        guard var selected = try? selectedBadges.value(),
+//              !selected.contains(title) else {
+//            return
+//        }
+        
+        if !selectedBadges.contains(title) {
+            selectedBadges.append(title)
             return
         }
-        
-        selected.append(title)
-        selectedBadges.onNext(selected)
     }
     
     func deselectBadge(title: String) {
-        guard var selected = try? selectedBadges.value(),
-              let removeIndex = selected.firstIndex(of: title) else {
+//        guard var selected = try? selectedBadges.value(),
+//              let removeIndex = selected.firstIndex(of: title) else {
+//            return
+//        }
+        
+        guard selectedBadges.contains(title),
+              let removeIndex = selectedBadges.firstIndex(of: title) else {
             return
         }
         
-        selected.remove(at: removeIndex)
-        selectedBadges.onNext(selected)
+        selectedBadges.remove(at: removeIndex)
     }
 }

--- a/Mogakco/Sources/Presentation/Study/ViewController/StudyDetailViewController.swift
+++ b/Mogakco/Sources/Presentation/Study/ViewController/StudyDetailViewController.swift
@@ -273,7 +273,7 @@ extension StudyDetailViewController: UICollectionViewDataSource {
             else { return UICollectionViewCell() }
             
             cell.prepareForReuse()
-            cell.setInfo(imageURLString: "", name: "김신오이", description: "iOS 개발자들")
+            cell.setInfo(imageURLString: "person", name: "김신오이", description: "iOS 개발자들")
             
             return cell
         


### PR DESCRIPTION
### PR Type

- [x]  기능 추가 🔨
- [ ]  버그 수정 🐞
- [ ]  리팩토링 🚧
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [ ]  테스트 🔍
 

### Related Issue(작업 내용)

close #48 
- Hashtag의 목록을 불러오는 HashtagUseCase 구현

close #54 
- HashTagUsecase에서 사용하는 HashtagRepository구현
- HashtagRepostory에  HashtagList를 불러오는 HashtagDataSource 구현

### 참고 사항

- DataSource는 API가 아닌 Asset에서 불러옵니다.
- Hashtag ViewController, ViewModel, Usecase, Repository 모두 하위 계층의 요소가 주입되도록 변경하였습니다.
- Rx를 이렇게 사용하는게 맞는지 조금 고민도는데 이상한 부분이 있다면 말씀해주세요!
- 로직이 단순해서 그런건지 모르겠는데 Usecase와 Repository가 그냥 계층만 나눠진 느낌입니다.
- tag를 모두 표시하니 간격 이슈가 약간 발생하는듯 합니다. 혹시 왼쪽 정렬이 가능한 방법이 있을까요?
  - 간격이 떨어지는 이유는 다음에 올 Hashtag가 현재 행에 다 들어가지 못 할 경우 생기는 듯 합니다.

### Screenshots
<img src="https://user-images.githubusercontent.com/86254784/202841319-195403d8-70a4-45e4-90d3-e88292aa4b3a.png" width="50%">

