### PR TITLE
UserDataSource 생성 및 User 조회 API 구현

### DIFF
--- a/Mogakco/Sources/Data/DataMapping/FirestoreValueDTOs.swift
+++ b/Mogakco/Sources/Data/DataMapping/FirestoreValueDTOs.swift
@@ -1,0 +1,125 @@
+//
+//  FirestoreValueDTOs.swift
+//  Mogakco
+//
+//  Created by 김범수 on 2022/11/21.
+//  Copyright © 2022 Mogakco. All rights reserved.
+//
+
+import Foundation
+
+struct StringValue: Codable {
+    let value: String
+    
+    init(value: String) {
+        self.value = value
+    }
+    
+    private enum CodingKeys: String, CodingKey {
+        case value = "stringValue"
+    }
+}
+
+struct IntegerValue: Codable {
+    let value: String
+    
+    private enum CodingKeys: String, CodingKey {
+        case value = "integerValue"
+    }
+}
+
+struct BooleanValue: Codable {
+    let value: Bool
+    
+    private enum CodingKeys: String, CodingKey {
+        case value = "booleanValue"
+    }
+}
+
+struct DoubleValue: Codable {
+    let value: Double
+    
+    private enum CodingKeys: String, CodingKey {
+        case value = "doubleValue"
+    }
+}
+
+struct TimeStampValue: Codable {
+    let value: String
+    
+    private enum CodingKeys: String, CodingKey {
+        case value = "timestampValue"
+    }
+}
+
+struct ArrayValue<T: Codable>: Codable {
+    let arrayValue: [String: [T]]
+    
+    private enum CodingKeys: String, CodingKey {
+        case arrayValue
+    }
+    
+    init(values: [T]) {
+        self.arrayValue = ["values": values]
+    }
+    
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.arrayValue = try container.decode([String: [T]].self, forKey: .arrayValue)
+    }
+}
+
+struct FieldValue: Codable {
+    var fields: [String: StringValue]
+    
+    private enum CodingKeys: String, CodingKey {
+        case fields
+    }
+    
+    init(value: [String: StringValue]) {
+        self.fields = value
+    }
+    
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.fields = try container.decode([String: StringValue].self, forKey: .fields)
+    }
+}
+
+struct DocumentsValue: Codable {
+    var value: [FieldValue]
+    
+    private enum CodingKeys: String, CodingKey {
+        case value = "documents"
+    }
+    
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.value = try container.decode([FieldValue].self, forKey: .value)
+    }
+}
+
+struct Documents<T: Codable>: Codable {
+    let documents: T
+    
+    private enum CodingKeys: String, CodingKey {
+        case documents
+    }
+}
+
+struct QueryResultValue<T: Codable>: Codable {
+    let readTime: String?
+    let document: T?
+    
+    private enum FieldKeys: String, CodingKey {
+        case readTime, document
+    }
+}
+
+struct Document: Codable {
+    let name: String?
+    
+    private enum CodingKeys: String, CodingKey {
+        case name
+    }
+}

--- a/Mogakco/Sources/Data/DataMapping/SignupRequestDTO.swift
+++ b/Mogakco/Sources/Data/DataMapping/SignupRequestDTO.swift
@@ -9,9 +9,18 @@
 import Foundation
 
 struct SignupRequestDTO: Encodable {
+    // TODO: private
     let email: String
     let password: String
     let name: String
     let languages: [String]
     let careers: [String]
+    
+    init(user: User) {
+        self.email = user.email
+        self.password = user.password ?? ""
+        self.name = user.name
+        self.languages = user.languages
+        self.careers = user.careers
+    }
 }

--- a/Mogakco/Sources/Data/DataMapping/SignupResponseDTO.swift
+++ b/Mogakco/Sources/Data/DataMapping/SignupResponseDTO.swift
@@ -9,6 +9,7 @@
 import Foundation
 
 struct SignupResponseDTO: Decodable {
+    // TODO: private
     let id: String
     let email: String
     let name: String

--- a/Mogakco/Sources/Data/DataMapping/UserRequestDTO.swift
+++ b/Mogakco/Sources/Data/DataMapping/UserRequestDTO.swift
@@ -1,0 +1,17 @@
+//
+//  UserRequestDTO.swift
+//  Mogakco
+//
+//  Created by 김범수 on 2022/11/21.
+//  Copyright © 2022 Mogakco. All rights reserved.
+//
+
+import Foundation
+
+struct UserRequestDTO: Encodable {
+    let id: String
+    
+    init(id: String) {
+        self.id = id
+    }
+}

--- a/Mogakco/Sources/Data/DataMapping/UserResponseDTO.swift
+++ b/Mogakco/Sources/Data/DataMapping/UserResponseDTO.swift
@@ -1,0 +1,54 @@
+//
+//  UserResponseDTO.swift
+//  Mogakco
+//
+//  Created by 김범수 on 2022/11/21.
+//  Copyright © 2022 Mogakco. All rights reserved.
+//
+
+import Foundation
+
+struct UserResponseDTO: Decodable {
+    private let id: StringValue
+    private let name: StringValue
+    private let email: StringValue
+    private let languages: ArrayValue<StringValue>
+    private let careers: ArrayValue<StringValue>
+    
+    private enum RootKey: String, CodingKey {
+        case fields
+    }
+    
+    private enum FieldKeys: String, CodingKey {
+        case id, name, email, languages, careers
+    }
+    
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: RootKey.self)
+        let fieldContainer = try container.nestedContainer(keyedBy: FieldKeys.self, forKey: .fields)
+        self.id = try fieldContainer.decode(StringValue.self, forKey: .id)
+        self.name = try fieldContainer.decode(StringValue.self, forKey: .name)
+        self.email = try fieldContainer.decode(StringValue.self, forKey: .email)
+        self.languages = try fieldContainer.decode(ArrayValue<StringValue>.self, forKey: .languages)
+        self.careers = try fieldContainer.decode(ArrayValue<StringValue>.self, forKey: .careers)
+    }
+    
+    init(user: User) {
+        self.id = StringValue(value: user.id ?? "")
+        self.name = StringValue(value: user.name)
+        self.email = StringValue(value: user.email)
+        self.languages = ArrayValue<StringValue>(values: user.languages.map { StringValue(value: $0) })
+        self.careers = ArrayValue<StringValue>(values: user.careers.map { StringValue(value: $0) })
+    }
+    
+    func toDomain() -> User {
+        return User(
+            id: id.value,
+            email: email.value,
+            password: nil,
+            name: name.value,
+            languages: languages.arrayValue.map { $0.value }.flatMap { $0.map { $0.value } },
+            careers: careers.arrayValue.map { $0.value }.flatMap { $0.map { $0.value } }
+        )
+    }
+}

--- a/Mogakco/Sources/Data/DataSources/Protocol/UserDataSourceProtocol.swift
+++ b/Mogakco/Sources/Data/DataSources/Protocol/UserDataSourceProtocol.swift
@@ -1,0 +1,13 @@
+//
+//  UserDataSourceProtocol.swift
+//  Mogakco
+//
+//  Created by 김범수 on 2022/11/21.
+//  Copyright © 2022 Mogakco. All rights reserved.
+//
+
+import RxSwift
+
+protocol UserDataSourceProtocol {
+    func user(request: UserRequestDTO) -> Observable<UserResponseDTO>
+}

--- a/Mogakco/Sources/Data/DataSources/Remote/FBAuthService.swift
+++ b/Mogakco/Sources/Data/DataSources/Remote/FBAuthService.swift
@@ -46,8 +46,8 @@ struct FBAuthService: AuthServiceProtocol {
                 "email": request.email,
                 "password": request.password,
                 "name": request.name,
-                "languages": request.languages,
-                "careers": request.careers
+                // "languages": request.languages,
+                // "careers": request.careers
             ]
             
             firestore.collection("User").document(id).setData(data) { error in

--- a/Mogakco/Sources/Data/DataSources/Remote/FBAuthService.swift
+++ b/Mogakco/Sources/Data/DataSources/Remote/FBAuthService.swift
@@ -40,12 +40,12 @@ struct FBAuthService: AuthServiceProtocol {
     
     private func createUser(request: SignupRequestDTO, id: String) -> Observable<SignupResponseDTO> {
         return Observable.create { emitter in
-            
+            // TODO: RestAPI
             let data = [
                 "id": id,
                 "email": request.email,
                 "password": request.password,
-                "name": request.name,
+                "name": request.name
                 // "languages": request.languages,
                 // "careers": request.careers
             ]

--- a/Mogakco/Sources/Data/DataSources/Remote/UserDataSource.swift
+++ b/Mogakco/Sources/Data/DataSources/Remote/UserDataSource.swift
@@ -1,0 +1,69 @@
+//
+//  UserDataSource.swift
+//  Mogakco
+//
+//  Created by 김범수 on 2022/11/21.
+//  Copyright © 2022 Mogakco. All rights reserved.
+//
+
+import Alamofire
+import RxSwift
+
+struct UserDataSource: UserDataSourceProtocol {
+    let provider: ProviderProtocol
+    
+    init(provider: ProviderProtocol) {
+        self.provider = provider
+    }
+    
+    func user(request: UserRequestDTO) -> Observable<UserResponseDTO> {
+        return provider.request(UserTarget.user(request))
+    }
+}
+
+enum UserTarget {
+    case user(UserRequestDTO)
+}
+
+extension UserTarget: TargetType {
+    var baseURL: String {
+        return "https://firestore.googleapis.com/v1/projects/mogakco-72df7/databases/(default)/documents"
+    }
+    
+    var method: HTTPMethod {
+        switch self {
+        case .user:
+            return .get
+        }
+    }
+    
+    var header: HTTPHeaders {
+        switch self {
+        case .user:
+            return [
+                "Content-Type": "application/json"
+            ]
+        }
+    }
+    
+    var path: String {
+        switch self {
+        case .user(let request):
+            return "/User/\(request.id)"
+        }
+    }
+    
+    var parameters: RequestParams? {
+        switch self {
+        case .user:
+            return nil
+        }
+    }
+    
+    var encoding: ParameterEncoding {
+        switch self {
+        case .user:
+            return JSONEncoding.default
+        }
+    }
+}

--- a/Mogakco/Sources/Data/Repositories/AuthRepository.swift
+++ b/Mogakco/Sources/Data/Repositories/AuthRepository.swift
@@ -18,13 +18,7 @@ struct AuthRepository: AuthRepositoryProtocol {
     }
     
     func signup(user: User) -> Observable<User> {
-        let request = SignupRequestDTO(
-            email: user.email,
-            password: user.password ?? "", // TODO: handling
-            name: user.name,
-            languages: user.languages,
-            careers: user.careers
-        )
+        let request = SignupRequestDTO(user: user)
         return authService
             .signup(request)
             .map { $0.toDomain() }

--- a/Mogakco/Sources/Data/Repositories/UserRepository.swift
+++ b/Mogakco/Sources/Data/Repositories/UserRepository.swift
@@ -11,13 +11,24 @@ import RxSwift
 struct UserRepository: UserRepositoryProtocol {
 
     private var localUserDataSource: LocalUserDataSourceProtocol
+    private var userDataSource: UserDataSourceProtocol
     private let disposeBag = DisposeBag()
     
-    init(localUserDataSource: LocalUserDataSourceProtocol) {
+    init(
+        localUserDataSource: LocalUserDataSourceProtocol,
+        userDataSource: UserDataSourceProtocol
+    ) {
         self.localUserDataSource = localUserDataSource
+        self.userDataSource = userDataSource
     }
 
     func save(user: User) -> Observable<Void> {
         return localUserDataSource.save(user: user)
+    }
+    
+    func user(id: String) -> Observable<User> {
+        let request = UserRequestDTO(id: id)
+        return userDataSource.user(request: request)
+            .map { $0.toDomain() }
     }
 }

--- a/Mogakco/Sources/Domain/Repositories/UserRepositoryProtocol.swift
+++ b/Mogakco/Sources/Domain/Repositories/UserRepositoryProtocol.swift
@@ -10,4 +10,5 @@ import RxSwift
 
 protocol UserRepositoryProtocol {
     func save(user: User) -> Observable<Void>
+    func user(id: String) -> Observable<User>
 }

--- a/Mogakco/Sources/Domain/UseCases/Protocol/SignupUseCaseProtocol.swift
+++ b/Mogakco/Sources/Domain/UseCases/Protocol/SignupUseCaseProtocol.swift
@@ -1,0 +1,13 @@
+//
+//  SignupUseCaseProtocol.swift
+//  Mogakco
+//
+//  Created by 김범수 on 2022/11/21.
+//  Copyright © 2022 Mogakco. All rights reserved.
+//
+
+import RxSwift
+
+protocol SignupUseCaseProtocol {
+    func signup(user: User) -> Observable<Void>
+}

--- a/Mogakco/Sources/Domain/UseCases/Protocol/UserUseCaseProtocol.swift
+++ b/Mogakco/Sources/Domain/UseCases/Protocol/UserUseCaseProtocol.swift
@@ -1,0 +1,13 @@
+//
+//  UserUseCaseProtocol.swift
+//  Mogakco
+//
+//  Created by 김범수 on 2022/11/21.
+//  Copyright © 2022 Mogakco. All rights reserved.
+//
+
+import RxSwift
+
+protocol UserUseCaseProtocol {
+    func user(id: String) -> Observable<User>
+}

--- a/Mogakco/Sources/Domain/UseCases/SignupUseCase.swift
+++ b/Mogakco/Sources/Domain/UseCases/SignupUseCase.swift
@@ -8,10 +8,6 @@
 
 import RxSwift
 
-protocol SignupUseCaseProtocol {
-    func signup(user: User) -> Observable<Void>
-}
-
 struct SignupUseCase: SignupUseCaseProtocol {
     
     private let authRepository: AuthRepositoryProtocol

--- a/Mogakco/Sources/Domain/UseCases/UserUseCase.swift
+++ b/Mogakco/Sources/Domain/UseCases/UserUseCase.swift
@@ -1,0 +1,23 @@
+//
+//  UserUseCase.swift
+//  Mogakco
+//
+//  Created by 김범수 on 2022/11/21.
+//  Copyright © 2022 Mogakco. All rights reserved.
+//
+
+import RxSwift
+
+struct UserUseCase: UserUseCaseProtocol {
+
+    private let userRepository: UserRepositoryProtocol
+    private let disposeBag = DisposeBag()
+    
+    init(userRepository: UserRepositoryProtocol) {
+        self.userRepository = userRepository
+    }
+    
+    func user(id: String) -> Observable<User> {
+        return userRepository.user(id: id)
+    }
+}

--- a/Mogakco/Sources/Network/NetworkEventLogger.swift
+++ b/Mogakco/Sources/Network/NetworkEventLogger.swift
@@ -1,0 +1,50 @@
+//
+//  NetworkEventLogger.swift
+//  Mogakco
+//
+//  Created by 김범수 on 2022/11/21.
+//  Copyright © 2022 Mogakco. All rights reserved.
+//
+
+import Foundation
+
+import Alamofire
+
+struct NetworkEventLogger: EventMonitor {
+    let queue = DispatchQueue(label: "NetworkEventLogger")
+
+    func requestDidFinish(_ request: Request) {
+        print("🛰 NETWORK Reqeust LOG")
+        print(request.description)
+
+        print(
+            "URL: " + (request.request?.url?.absoluteString ?? "") + "\n"
+                + "Method: " + (request.request?.httpMethod ?? "") + "\n"
+                + "Headers: " + "\(request.request?.allHTTPHeaderFields ?? [:])" + "\n"
+        )
+        print("Authorization: " + (request.request?.headers["Authorization"] ?? ""))
+        print("Body: " + (request.request?.httpBody?.toPrettyPrintedString ?? ""))
+    }
+
+    func request<Value>(_ request: DataRequest, didParseResponse response: DataResponse<Value, AFError>) {
+        print("🛰 NETWORK Response LOG")
+        print(
+            "URL: " + (request.request?.url?.absoluteString ?? "") + "\n"
+                + "Result: " + "\(response.result)" + "\n"
+                + "StatusCode: " + "\(response.response?.statusCode ?? 0)" + "\n"
+                + "Data: \(response.data?.toPrettyPrintedString ?? "")"
+        )
+    }
+}
+
+extension Data {
+    var toPrettyPrintedString: String? {
+        guard let object = try? JSONSerialization.jsonObject(with: self, options: []),
+              let data = try? JSONSerialization.data(withJSONObject: object, options: [.prettyPrinted]),
+              let prettyPrintedString = NSString(
+                data: data,
+                encoding: String.Encoding.utf8.rawValue
+              ) else { return nil }
+        return prettyPrintedString as String
+    }
+}

--- a/Mogakco/Sources/Network/Provider.swift
+++ b/Mogakco/Sources/Network/Provider.swift
@@ -1,0 +1,51 @@
+//
+//  Provider.swift
+//  Mogakco
+//
+//  Created by 김범수 on 2022/11/21.
+//  Copyright © 2022 Mogakco. All rights reserved.
+//
+
+import Foundation
+
+import Alamofire
+import RxSwift
+
+struct EmptyResponse: Decodable {}
+struct EmptyParameter: Encodable {}
+
+class Provider: ProviderProtocol {
+    private let session: Session
+
+    init(session: Session) {
+        self.session = session
+    }
+    
+    static let `default`: Provider = {
+        let configuration = URLSessionConfiguration.af.default
+        configuration.timeoutIntervalForRequest = 10
+        configuration.timeoutIntervalForResource = 10
+        let networkEventLogger = NetworkEventLogger()
+        let session = Session(configuration: configuration, eventMonitors: [networkEventLogger])
+        return Provider(session: session)
+    }()
+    
+    func request<T: Decodable>(_ urlConvertible: URLRequestConvertible) -> Observable<T> {
+        return Observable.create { emitter in
+            let request = self.session
+                .request(urlConvertible)
+                .validate(statusCode: 200 ..< 300)
+                .responseDecodable(of: T.self) { response in
+                    switch response.result {
+                    case let .success(data):
+                        emitter.onNext(data)
+                    case let .failure(error):
+                        emitter.onError(error)
+                    }
+                }
+            return Disposables.create {
+                request.cancel()
+            }
+        }
+    }
+}

--- a/Mogakco/Sources/Network/ProviderProtocol.swift
+++ b/Mogakco/Sources/Network/ProviderProtocol.swift
@@ -1,0 +1,14 @@
+//
+//  NetworkProtocol.swift
+//  Mogakco
+//
+//  Created by 김범수 on 2022/11/21.
+//  Copyright © 2022 Mogakco. All rights reserved.
+//
+
+import Alamofire
+import RxSwift
+
+public protocol ProviderProtocol: AnyObject {
+    func request<T: Decodable>(_ urlConvertible: URLRequestConvertible) -> Observable<T>
+}

--- a/Mogakco/Sources/Network/TargetType.swift
+++ b/Mogakco/Sources/Network/TargetType.swift
@@ -1,0 +1,58 @@
+//
+//  TargetType.swift
+//  Mogakco
+//
+//  Created by 김범수 on 2022/11/21.
+//  Copyright © 2022 Mogakco. All rights reserved.
+//
+
+import Foundation
+
+import Alamofire
+
+protocol TargetType: URLRequestConvertible {
+    var baseURL: String { get }
+    var method: HTTPMethod { get }
+    var header: HTTPHeaders { get }
+    var path: String { get }
+    var parameters: RequestParams? { get }
+    var encoding: ParameterEncoding { get }
+}
+
+extension TargetType {
+    func asURLRequest() throws -> URLRequest {
+        let url = try baseURL.asURL()
+        var urlRequest = try URLRequest(url: url.appendingPathComponent(path), method: method)
+        urlRequest.headers = header
+
+        switch parameters {
+        case let .query(request):
+            let params = request?.toDictionary() ?? [:]
+            let queryParams = params.map { URLQueryItem(name: $0.key, value: "\($0.value)") }
+            var components = URLComponents(string: url.appendingPathComponent(path).absoluteString)
+            components?.queryItems = queryParams
+            urlRequest.url = components?.url
+            return try encoding.encode(urlRequest, with: params)
+        case let .body(request):
+            let params = request?.toDictionary() ?? [:]
+            urlRequest.httpBody = try JSONSerialization.data(withJSONObject: params, options: [])
+            return try encoding.encode(urlRequest, with: params)
+        case .none:
+            return urlRequest
+        }
+    }
+}
+
+enum RequestParams {
+    case query(_ parameter: Encodable?)
+    case body(_ parameter: Encodable?)
+}
+
+extension Encodable {
+    func toDictionary() -> [String: Any] {
+        guard let data = try? JSONEncoder().encode(self),
+              let jsonData = try? JSONSerialization.jsonObject(with: data),
+              let dictionaryData = jsonData as? [String: Any] else { return [:] }
+        return dictionaryData
+    }
+}


### PR DESCRIPTION
### PR Type

- [x]  기능 추가 🔨
- [ ]  버그 수정 🐞
- [ ]  리팩토링 🚧
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [ ]  테스트 🔍
 

### Related Issue(작업 내용)

- UserDataSource를 생성하고 UserTarget을 통해 User 조회 API를 구현하였습니다.
- UserRepository 내 유저 조회 기능을 추가하였습니다.
- resolve #15 
  - UserUseCase 내 유저 조회 기능을 추가하였습니다.

### 테스트 방법
``` swift
let userUseCase = UserUseCase(
    userRepository: UserRepository(
        localUserDataSource: UserDefaultsUserDataSource(),
        userDataSource: UserDataSource(provider: Provider.default)
    )
)

userUseCase.user(id: "4ASoN4MWU3RuZJDbjUNjAwtx7Vl1")
    .subscribe {
        dump($0)
    }
    .disposed(by: disposeBag)
```
위 코드 실행 후 출력확인하시면 됩니다.

### Screenshots(Optional)
<img src="https://user-images.githubusercontent.com/73675540/202997215-629041a0-1f30-4a4b-bcbd-51bf9f1b93c1.png" width="50%">
