### PR TITLE
채팅방 목록 API 구현 및 데이터 바인딩

### DIFF
--- a/Mogakco/Sources/Data/DataMapping/ChatResponseDTO.swift
+++ b/Mogakco/Sources/Data/DataMapping/ChatResponseDTO.swift
@@ -1,0 +1,39 @@
+//
+//  ChatResponseDTO.swift
+//  Mogakco
+//
+//  Created by 김범수 on 2022/11/21.
+//  Copyright © 2022 Mogakco. All rights reserved.
+//
+
+import Foundation
+
+struct ChatResponseDTO: Codable {
+    private let id: StringValue
+    private let userID: StringValue
+    private let message: StringValue
+    
+    private enum RootKey: String, CodingKey {
+        case fields
+    }
+    
+    private enum FieldKeys: String, CodingKey {
+        case id, userID, message
+    }
+    
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: RootKey.self)
+        let fieldContainer = try container.nestedContainer(keyedBy: FieldKeys.self, forKey: .fields)
+        self.id = try fieldContainer.decode(StringValue.self, forKey: .id)
+        self.userID = try fieldContainer.decode(StringValue.self, forKey: .userID)
+        self.message = try fieldContainer.decode(StringValue.self, forKey: .message)
+    }
+    
+    func toDomain() -> Chat {
+        return Chat(
+            id: id.value,
+            userID: userID.value,
+            message: message.value
+        )
+    }
+}

--- a/Mogakco/Sources/Data/DataMapping/ChatRoomResponseDTO.swift
+++ b/Mogakco/Sources/Data/DataMapping/ChatRoomResponseDTO.swift
@@ -1,0 +1,39 @@
+//
+//  ChatRoomResponseDTO.swift
+//  Mogakco
+//
+//  Created by 김범수 on 2022/11/21.
+//  Copyright © 2022 Mogakco. All rights reserved.
+//
+
+import Foundation
+
+struct ChatRoomResponseDTO: Codable {
+    private let id: StringValue
+    private let studyID: StringValue
+    private let userIDs: ArrayValue<StringValue>
+    
+    private enum RootKey: String, CodingKey {
+        case fields
+    }
+    
+    private enum FieldKeys: String, CodingKey {
+        case id, studyID, messageIDs, userIDs
+    }
+    
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: RootKey.self)
+        let fieldContainer = try container.nestedContainer(keyedBy: FieldKeys.self, forKey: .fields)
+        self.id = try fieldContainer.decode(StringValue.self, forKey: .id)
+        self.studyID = try fieldContainer.decode(StringValue.self, forKey: .studyID)
+        self.userIDs = try fieldContainer.decode(ArrayValue<StringValue>.self, forKey: .userIDs)
+    }
+    
+    func toDomain() -> ChatRoom {
+        return ChatRoom(
+            id: id.value,
+            studyID: studyID.value,
+            userIDs: userIDs.arrayValue.map { $0.value }.flatMap { $0.map { $0.value } }
+        )
+    }
+}

--- a/Mogakco/Sources/Data/DataSources/Protocol/ChatDataSourceProtocol.swift
+++ b/Mogakco/Sources/Data/DataSources/Protocol/ChatDataSourceProtocol.swift
@@ -1,0 +1,13 @@
+//
+//  ChatDataSourceProtocol.swift
+//  Mogakco
+//
+//  Created by 김범수 on 2022/11/21.
+//  Copyright © 2022 Mogakco. All rights reserved.
+//
+
+import RxSwift
+
+protocol ChatDataSourceProtocol {
+    func all(chatRoomID: String) -> Observable<Documents<[ChatResponseDTO]>>
+}

--- a/Mogakco/Sources/Data/DataSources/Protocol/ChatRoomDataSourceProtocol.swift
+++ b/Mogakco/Sources/Data/DataSources/Protocol/ChatRoomDataSourceProtocol.swift
@@ -1,0 +1,13 @@
+//
+//  ChatRoomDataSourceProtocol.swift
+//  Mogakco
+//
+//  Created by 김범수 on 2022/11/21.
+//  Copyright © 2022 Mogakco. All rights reserved.
+//
+
+import RxSwift
+
+protocol ChatRoomDataSourceProtocol {
+    func list() -> Observable<Documents<[ChatRoomResponseDTO]>>
+}

--- a/Mogakco/Sources/Data/DataSources/Remote/ChatDataSource.swift
+++ b/Mogakco/Sources/Data/DataSources/Remote/ChatDataSource.swift
@@ -1,5 +1,5 @@
 //
-//  UserDataSource.swift
+//  ChatDataSource.swift
 //  Mogakco
 //
 //  Created by 김범수 on 2022/11/21.
@@ -9,37 +9,38 @@
 import Alamofire
 import RxSwift
 
-struct UserDataSource: UserDataSourceProtocol {
+struct ChatDataSource: ChatDataSourceProtocol {
+
     let provider: ProviderProtocol
     
     init(provider: ProviderProtocol) {
         self.provider = provider
     }
     
-    func user(request: UserRequestDTO) -> Observable<UserResponseDTO> {
-        return provider.request(UserTarget.user(request))
+    func all(chatRoomID: String) -> Observable<Documents<[ChatResponseDTO]>> {
+        return provider.request(ChatTarget.all(chatRoomID))
     }
 }
 
-enum UserTarget {
-    case user(UserRequestDTO)
+enum ChatTarget {
+    case all(String)
 }
 
-extension UserTarget: TargetType {
+extension ChatTarget: TargetType {
     var baseURL: String {
-        return "https://firestore.googleapis.com/v1/projects/mogakco-72df7/databases/(default)/documents/User"
+        return "https://firestore.googleapis.com/v1/projects/mogakco-72df7/databases/(default)/documents/ChatRoom"
     }
     
     var method: HTTPMethod {
         switch self {
-        case .user:
+        case .all:
             return .get
         }
     }
     
     var header: HTTPHeaders {
         switch self {
-        case .user:
+        case .all:
             return [
                 "Content-Type": "application/json"
             ]
@@ -48,21 +49,21 @@ extension UserTarget: TargetType {
     
     var path: String {
         switch self {
-        case .user(let request):
-            return "/\(request.id)"
+        case .all(let chatRoomID):
+            return "/\(chatRoomID)/chats"
         }
     }
     
     var parameters: RequestParams? {
         switch self {
-        case .user:
+        case .all:
             return nil
         }
     }
     
     var encoding: ParameterEncoding {
         switch self {
-        case .user:
+        case .all:
             return JSONEncoding.default
         }
     }

--- a/Mogakco/Sources/Data/DataSources/Remote/ChatRoomDataSource.swift
+++ b/Mogakco/Sources/Data/DataSources/Remote/ChatRoomDataSource.swift
@@ -1,0 +1,69 @@
+//
+//  ChatRoomDataSource.swift
+//  Mogakco
+//
+//  Created by 김범수 on 2022/11/21.
+//  Copyright © 2022 Mogakco. All rights reserved.
+//
+
+import Alamofire
+import RxSwift
+
+struct ChatRoomDataSource: ChatRoomDataSourceProtocol {
+    let provider: ProviderProtocol
+    
+    init(provider: ProviderProtocol) {
+        self.provider = provider
+    }
+    
+    func list() -> Observable<Documents<[ChatRoomResponseDTO]>> {
+        return provider.request(ChatRoomTarget.list)
+    }
+}
+
+enum ChatRoomTarget {
+    case list
+}
+
+extension ChatRoomTarget: TargetType {
+    var baseURL: String {
+        return "https://firestore.googleapis.com/v1/projects/mogakco-72df7/databases/(default)/documents/ChatRoom"
+    }
+    
+    var method: HTTPMethod {
+        switch self {
+        case .list:
+            return .get
+        }
+    }
+    
+    var header: HTTPHeaders {
+        switch self {
+        case .list:
+            return [
+                "Content-Type": "application/json"
+            ]
+        }
+    }
+    
+    var path: String {
+        switch self {
+        case .list:
+            return ""
+        }
+    }
+    
+    var parameters: RequestParams? {
+        switch self {
+        case .list:
+            return nil
+        }
+    }
+    
+    var encoding: ParameterEncoding {
+        switch self {
+        case .list:
+            return JSONEncoding.default
+        }
+    }
+}

--- a/Mogakco/Sources/Data/Repositories/ChatRoomRepository.swift
+++ b/Mogakco/Sources/Data/Repositories/ChatRoomRepository.swift
@@ -1,0 +1,28 @@
+//
+//  ChatRoomRepository.swift
+//  Mogakco
+//
+//  Created by 김범수 on 2022/11/21.
+//  Copyright © 2022 Mogakco. All rights reserved.
+//
+
+import RxSwift
+
+struct ChatRoomRepository: ChatRoomRepositoryProtocol {
+    private let chatRoomDataSource: ChatRoomDataSourceProtocol
+    private let chatDataSource: ChatDataSourceProtocol
+    private let disposeBag = DisposeBag()
+    
+    init(
+        chatRoomDataSource: ChatRoomDataSourceProtocol,
+        chatDataSource: ChatDataSourceProtocol
+    ) {
+        self.chatRoomDataSource = chatRoomDataSource
+        self.chatDataSource = chatDataSource
+    }
+
+    func list() -> Observable<[ChatRoom]> {
+        return chatRoomDataSource.list()
+            .map { $0.documents.map { $0.toDomain() } } // TODO: Lastest Chat
+    }
+}

--- a/Mogakco/Sources/Domain/Entities/Chat.swift
+++ b/Mogakco/Sources/Domain/Entities/Chat.swift
@@ -1,0 +1,15 @@
+//
+//  Chat.swift
+//  Mogakco
+//
+//  Created by 김범수 on 2022/11/21.
+//  Copyright © 2022 Mogakco. All rights reserved.
+//
+
+import Foundation
+
+struct Chat {
+    let id: String
+    let userID: String
+    let message: String
+}

--- a/Mogakco/Sources/Domain/Entities/ChatRoom.swift
+++ b/Mogakco/Sources/Domain/Entities/ChatRoom.swift
@@ -1,0 +1,15 @@
+//
+//  ChatRoom.swift
+//  Mogakco
+//
+//  Created by 김범수 on 2022/11/21.
+//  Copyright © 2022 Mogakco. All rights reserved.
+//
+
+import Foundation
+
+struct ChatRoom {
+    let id: String
+    let studyID: String
+    let userIDs: [String]
+}

--- a/Mogakco/Sources/Domain/Repositories/ChatRoomRepositoryProtocol.swift
+++ b/Mogakco/Sources/Domain/Repositories/ChatRoomRepositoryProtocol.swift
@@ -1,0 +1,13 @@
+//
+//  ChatRoomRepositoryProtocol.swift
+//  Mogakco
+//
+//  Created by 김범수 on 2022/11/21.
+//  Copyright © 2022 Mogakco. All rights reserved.
+//
+
+import RxSwift
+
+protocol ChatRoomRepositoryProtocol {
+    func list() -> Observable<[ChatRoom]>
+}

--- a/Mogakco/Sources/Domain/UseCases/ChatRoomListUseCase.swift
+++ b/Mogakco/Sources/Domain/UseCases/ChatRoomListUseCase.swift
@@ -1,0 +1,23 @@
+//
+//  ChatRoomListUseCase.swift
+//  Mogakco
+//
+//  Created by 김범수 on 2022/11/21.
+//  Copyright © 2022 Mogakco. All rights reserved.
+//
+
+import RxSwift
+
+struct ChatRoomListUseCase: ChatRoomListUseCaseProtocol {
+
+    private let chatRoomRepository: ChatRoomRepositoryProtocol
+    private let disposeBag = DisposeBag()
+    
+    init(chatRoomRepository: ChatRoomRepositoryProtocol) {
+        self.chatRoomRepository = chatRoomRepository
+    }
+    
+    func list() -> Observable<[ChatRoom]> {
+        return chatRoomRepository.list()
+    }
+}

--- a/Mogakco/Sources/Domain/UseCases/Protocol/ChatRoomListUseCaseProtocol.swift
+++ b/Mogakco/Sources/Domain/UseCases/Protocol/ChatRoomListUseCaseProtocol.swift
@@ -1,0 +1,13 @@
+//
+//  ChatRoomListUseCaseProtocol.swift
+//  Mogakco
+//
+//  Created by 김범수 on 2022/11/21.
+//  Copyright © 2022 Mogakco. All rights reserved.
+//
+
+import RxSwift
+
+protocol ChatRoomListUseCaseProtocol {
+    func list() -> Observable<[ChatRoom]>
+}

--- a/Mogakco/Sources/Presentation/Chat/View/ChatRoomTableViewCell.swift
+++ b/Mogakco/Sources/Presentation/Chat/View/ChatRoomTableViewCell.swift
@@ -19,28 +19,24 @@ final class ChatRoomTableViewCell: UITableViewCell, Identifiable {
     }
     
     private let chatRoomTitleLabel = UILabel().then {
-        $0.text = "Swift 공부방"
         $0.textAlignment = .left
         $0.font = UIFont.mogakcoFont.mediumBold
         $0.textColor = UIColor.mogakcoColor.typographyPrimary
     }
     
     private let latestMessageLabel = UILabel().then {
-        $0.text = "언제 만날까요"
         $0.textAlignment = .left
         $0.font = UIFont.mogakcoFont.smallRegular
         $0.textColor = UIColor.mogakcoColor.typographySecondary
     }
     
     private let latestMessageDateLabel = UILabel().then {
-        $0.text = "오후 2:09"
         $0.textAlignment = .right
         $0.font = UIFont.mogakcoFont.smallRegular
         $0.textColor = UIColor.mogakcoColor.typographySecondary
     }
     
     private let unreadMessageCountLabel = UILabel().then {
-        $0.text = "30"
         $0.textAlignment = .center
         $0.backgroundColor = UIColor.mogakcoColor.primarySecondary
         $0.font = UIFont.mogakcoFont.caption
@@ -60,6 +56,10 @@ final class ChatRoomTableViewCell: UITableViewCell, Identifiable {
         super.layoutSubviews()
         configureChatRoomImageViewCornerRadius()
         configureUnreadMessageCountLabelCornerRadius()
+    }
+    
+    func configure(chatRoom: ChatRoom) {
+        chatRoomTitleLabel.text = chatRoom.userIDs.joined()
     }
     
     private func layout() {

--- a/Mogakco/Sources/Presentation/Chat/ViewController/ChatListViewController.swift
+++ b/Mogakco/Sources/Presentation/Chat/ViewController/ChatListViewController.swift
@@ -54,15 +54,17 @@ final class ChatListViewController: UIViewController {
         let input = ChatListViewModel.Input(
             selectedChatRoom: chatRoomTableView.rx.itemSelected.map { _ in }.asObservable()
         )
-        _ = viewModel.transform(input: input)
+        let output = viewModel.transform(input: input)
         
-        Driver<[Int]>.just([1, 2, 3, 4])
-            .drive(chatRoomTableView.rx.items) { tableView, index, _ in
+        output.chatRoomList
+            .asDriver(onErrorJustReturn: [])
+            .drive(chatRoomTableView.rx.items) { tableView, index, chatRoom in
                 guard let cell = tableView.dequeueReusableCell(
                     withIdentifier: ChatRoomTableViewCell.identifier,
                     for: IndexPath(row: index, section: 0)) as? ChatRoomTableViewCell else {
                     return UITableViewCell()
                 }
+                cell.configure(chatRoom: chatRoom)
                 return cell
             }
             .disposed(by: disposeBag)

--- a/Mogakco/Sources/Presentation/Chat/ViewModel/ChatListViewModel.swift
+++ b/Mogakco/Sources/Presentation/Chat/ViewModel/ChatListViewModel.swift
@@ -18,13 +18,19 @@ final class ChatListViewModel: ViewModel {
     }
     
     struct Output {
+        let chatRoomList: Observable<[ChatRoom]>
     }
     
     var disposeBag = DisposeBag()
     weak var coordinator: ChatTabCoordinator?
+    let chatRoomListUseCase: ChatRoomListUseCaseProtocol
  
-    init(coordinator: ChatTabCoordinator) {
+    init(
+        coordinator: ChatTabCoordinator,
+        chatRoomListUseCase: ChatRoomListUseCaseProtocol
+    ) {
         self.coordinator = coordinator
+        self.chatRoomListUseCase = chatRoomListUseCase
     }
     
     func transform(input: Input) -> Output {
@@ -36,6 +42,12 @@ final class ChatListViewModel: ViewModel {
             })
             .disposed(by: disposeBag)
         
-        return Output()
+        let chatRoomList = Observable.just(())
+            .withUnretained(self)
+            .flatMap { $0.0.chatRoomListUseCase.list() }
+        
+        return Output(
+            chatRoomList: chatRoomList.asObservable()
+        )
     }
 }

--- a/Mogakco/Sources/Presentation/Common/Coordinator/ChatTabCoordinator.swift
+++ b/Mogakco/Sources/Presentation/Common/Coordinator/ChatTabCoordinator.swift
@@ -23,7 +23,15 @@ final class ChatTabCoordinator: Coordinator, ChatTabCoordinatorProtocol {
     }
     
     func showChatList() {
-        let viewModel = ChatListViewModel(coordinator: self)
+        let viewModel = ChatListViewModel(
+            coordinator: self,
+            chatRoomListUseCase: ChatRoomListUseCase(
+                chatRoomRepository: ChatRoomRepository(
+                    chatRoomDataSource: ChatRoomDataSource(provider: Provider.default),
+                    chatDataSource: ChatDataSource(provider: Provider.default)
+                )
+            )
+        )
         let viewController = ChatListViewController(viewModel: viewModel)
         navigationController.pushViewController(viewController, animated: false)
     }


### PR DESCRIPTION
### PR Type

- [x]  기능 추가 🔨
- [ ]  버그 수정 🐞
- [ ]  리팩토링 🚧
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [ ]  테스트 🔍
 

### Related Issue(작업 내용)

- resolves #151 
    - ChatRoomListUseCase 채팅방 목록 호출 기능 구현
- resolves #14 
  - ChatRoomRepository, ChatRoomDataSource 채팅방 목록 API 구현
- 채팅방 목록 데이터 바인딩

### 참고 사항
우선 전체 채팅방 목록을 불러와 UI에 바인딩하였습니다.
최근 메세지, 유저의 채팅방만 불러오도록 #164 이슈에서 처리하도록 하겠습니다

### Screenshots(Optional)
<img src="https://user-images.githubusercontent.com/73675540/203091316-223379cb-ae93-4aa5-b67b-cf29eaac2818.png" width="50%">
