### PR TITLE
로그인 API 구현

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -10,7 +10,8 @@ excluded:
 disabled_rules:
   - trailing_whitespace
   - todo
-
+  - cyclomatic_complexity
+  
 opt_in_rules:
   - array_init
   - attributes

--- a/Mogakco/Sources/Data/DataSources/Local/UserDefaultsUserDataSource.swift
+++ b/Mogakco/Sources/Data/DataSources/Local/UserDefaultsUserDataSource.swift
@@ -11,8 +11,10 @@ import Foundation
 import RxSwift
 
 struct UserDefaultsUserDataSource: LocalUserDataSourceProtocol {
+    
     private let userKey = "user"
-
+    private let userUIDKey = "userUID"
+    
     func save(user: User) -> Observable<Void> {
         return Observable.create { emitter in
             do {
@@ -41,6 +43,14 @@ struct UserDefaultsUserDataSource: LocalUserDataSourceProtocol {
     func remove() -> Observable<Void> {
         return Observable.create { emitter in
             UserDefaults.standard.removeObject(forKey: userKey)
+            emitter.onNext(())
+            return Disposables.create()
+        }
+    }
+    
+    func saveUID(userUID: String) -> RxSwift.Observable<Void> {
+        return Observable.create { emitter in
+            UserDefaults.standard.set(userUID, forKey: userUIDKey)
             emitter.onNext(())
             return Disposables.create()
         }

--- a/Mogakco/Sources/Data/DataSources/Protocol/AuthServiceProtocol.swift
+++ b/Mogakco/Sources/Data/DataSources/Protocol/AuthServiceProtocol.swift
@@ -10,4 +10,5 @@ import RxSwift
 
 protocol AuthServiceProtocol {
     func signup(_ request: SignupRequestDTO) -> Observable<SignupResponseDTO>
+    func login(_ request: EmailLoginData) -> Observable<String>
 }

--- a/Mogakco/Sources/Data/DataSources/Protocol/LocalUserDataSourceProtocol.swift
+++ b/Mogakco/Sources/Data/DataSources/Protocol/LocalUserDataSourceProtocol.swift
@@ -12,4 +12,6 @@ protocol LocalUserDataSourceProtocol {
     func save(user: User) -> Observable<Void>
     func load() -> Observable<User>
     func remove() -> Observable<Void>
+    
+    func saveUID(userUID: String) -> Observable<Void>
 }

--- a/Mogakco/Sources/Data/DataSources/Remote/FBAuthService.swift
+++ b/Mogakco/Sources/Data/DataSources/Remote/FBAuthService.swift
@@ -72,4 +72,20 @@ struct FBAuthService: AuthServiceProtocol {
             return Disposables.create()
         }
     }
+    
+    func login(_ request: EmailLoginData) -> Observable<String> {
+        return Observable.create { emmiter in
+            Auth.auth().signIn(withEmail: request.email, password: request.password) { result, error in
+                if let id = result?.user.uid,
+                   error == nil {
+                    emmiter.onNext(id)
+                } else {
+                    if let error {
+                        emmiter.onError(error)
+                    }
+                }
+            }
+            return Disposables.create()
+        }
+    }
 }

--- a/Mogakco/Sources/Data/Repositories/AuthRepository.swift
+++ b/Mogakco/Sources/Data/Repositories/AuthRepository.swift
@@ -9,7 +9,7 @@
 import RxSwift
 
 struct AuthRepository: AuthRepositoryProtocol {
-
+    
     private var authService: AuthServiceProtocol
     private let disposeBag = DisposeBag()
     
@@ -22,5 +22,9 @@ struct AuthRepository: AuthRepositoryProtocol {
         return authService
             .signup(request)
             .map { $0.toDomain() }
+    }
+    
+    func login(emailLoginData: EmailLoginData) -> Observable<String> {
+        return authService.login(emailLoginData)
     }
 }

--- a/Mogakco/Sources/Data/Repositories/UserRepository.swift
+++ b/Mogakco/Sources/Data/Repositories/UserRepository.swift
@@ -26,6 +26,8 @@ struct UserRepository: UserRepositoryProtocol {
         return localUserDataSource.save(user: user)
     }
     
+    func save(userUID: String) -> Observable<Void> {
+        return localUserDataSource.saveUID(userUID: userUID)
     func user(id: String) -> Observable<User> {
         let request = UserRequestDTO(id: id)
         return userDataSource.user(request: request)

--- a/Mogakco/Sources/Domain/Entities/EmailLogin.swift
+++ b/Mogakco/Sources/Domain/Entities/EmailLogin.swift
@@ -1,0 +1,14 @@
+//
+//  EmailLogin.swift
+//  Mogakco
+//
+//  Created by 이주훈 on 2022/11/21.
+//  Copyright © 2022 Mogakco. All rights reserved.
+//
+
+import Foundation
+
+struct EmailLoginData {
+    let email: String
+    let password: String
+}

--- a/Mogakco/Sources/Domain/Repositories/AuthRepositoryProtocol.swift
+++ b/Mogakco/Sources/Domain/Repositories/AuthRepositoryProtocol.swift
@@ -10,4 +10,5 @@ import RxSwift
 
 protocol AuthRepositoryProtocol {
     func signup(user: User) -> Observable<User>
+    func login(emailLoginData: EmailLoginData) -> Observable<String>
 }

--- a/Mogakco/Sources/Domain/Repositories/UserRepositoryProtocol.swift
+++ b/Mogakco/Sources/Domain/Repositories/UserRepositoryProtocol.swift
@@ -10,6 +10,7 @@ import RxSwift
 
 protocol UserRepositoryProtocol {
     func save(user: User) -> Observable<Void>
+    func save(userUID: String) -> Observable<Void>
     func user(id: String) -> Observable<User>
     func load() -> Observable<User>
 }

--- a/Mogakco/Sources/Domain/UseCases/LoginUseCase.swift
+++ b/Mogakco/Sources/Domain/UseCases/LoginUseCase.swift
@@ -1,0 +1,33 @@
+//
+//  LoginUseCase.swift
+//  Mogakco
+//
+//  Created by 이주훈 on 2022/11/21.
+//  Copyright © 2022 Mogakco. All rights reserved.
+//
+
+import Foundation
+
+import RxSwift
+
+struct LoginUseCase: LoginUseCaseProtocol {
+    
+    private let authRepository: AuthRepositoryProtocol
+    private let userRepository: UserRepositoryProtocol
+    private let disposeBag = DisposeBag()
+    
+    init(
+        authRepository: AuthRepositoryProtocol,
+        userRepository: UserRepositoryProtocol
+    ) {
+        self.authRepository = authRepository
+        self.userRepository = userRepository
+    }
+    
+    func login(emailLoginData: EmailLoginData) -> Observable<Void> {
+        let isLoginSuccess = PublishSubject<Void>()
+        
+        return authRepository.login(emailLoginData: emailLoginData)
+            .flatMap { userRepository.save(userUID: $0) }
+    }
+}

--- a/Mogakco/Sources/Domain/UseCases/Protocol/LoginUseCaseProtocol.swift
+++ b/Mogakco/Sources/Domain/UseCases/Protocol/LoginUseCaseProtocol.swift
@@ -1,0 +1,15 @@
+//
+//  LoginUseCaseProtocol.swift
+//  Mogakco
+//
+//  Created by 이주훈 on 2022/11/21.
+//  Copyright © 2022 Mogakco. All rights reserved.
+//
+
+import Foundation
+
+import RxSwift
+
+protocol LoginUseCaseProtocol {
+    func login(emailLoginData: EmailLoginData) -> Observable<Void>
+}

--- a/Mogakco/Sources/Presentation/HashtagSelect/ViewModel/HashtagSelectViewModel.swift
+++ b/Mogakco/Sources/Presentation/HashtagSelect/ViewModel/HashtagSelectViewModel.swift
@@ -75,7 +75,6 @@ final class HashtagSelectViewModel: ViewModel {
         input.nextButtonTapped
             .subscribe(onNext: {
                 // TODO: 분기처리 필요
-                self.coordinator?.finish(success: true)
             })
             .disposed(by: disposeBag)
         

--- a/Mogakco/Sources/Presentation/Login/ViewController/LoginViewController.swift
+++ b/Mogakco/Sources/Presentation/Login/ViewController/LoginViewController.swift
@@ -15,7 +15,6 @@ import Then
 final class LoginViewController: ViewController {
     
     private let emailTextField = MessageTextField()
-    
     private let secureTextField = SecureTextField()
     
     private let signupButton = UIButton().then {
@@ -67,6 +66,7 @@ final class LoginViewController: ViewController {
     }
     
     override func bind() {
+        //
     }
     
     override func layout() {

--- a/Mogakco/Sources/Presentation/Login/ViewModel/LoginViewModel.swift
+++ b/Mogakco/Sources/Presentation/Login/ViewModel/LoginViewModel.swift
@@ -1,0 +1,34 @@
+//
+//  LoginViewModel.swift
+//  Mogakco
+//
+//  Created by 이주훈 on 2022/11/21.
+//  Copyright © 2022 Mogakco. All rights reserved.
+//
+
+import Foundation
+
+import RxSwift
+
+final class LoginViewModel: ViewModel {
+    
+    struct Input {
+        //
+    }
+    
+    struct Output {
+        //
+    }
+    
+    var disposeBag = DisposeBag()
+    var loginUseCase: LoginUseCaseProtocol
+    
+    init(loginUseCase: LoginUseCaseProtocol) {
+        self.loginUseCase = loginUseCase
+    }
+    
+    func transform(input: Input) -> Output {
+            
+        return Output()
+    }
+}

--- a/Mogakco/Sources/Util/Error/LoginError.swift
+++ b/Mogakco/Sources/Util/Error/LoginError.swift
@@ -1,0 +1,13 @@
+//
+//  LoginError.swift
+//  Mogakco
+//
+//  Created by 이주훈 on 2022/11/21.
+//  Copyright © 2022 Mogakco. All rights reserved.
+//
+
+import Foundation
+
+enum LoginError: Error, LocalizedError {
+    case passwordIsEmpty
+}


### PR DESCRIPTION
### PR Type

- [x]  기능 추가 🔨
- [ ]  버그 수정 🐞
- [ ]  리팩토링 🚧
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [ ]  테스트 🔍
 

### Related Issue(작업 내용)
- close #44 
  - 로그인 Usecase, Repository 프로토콜과 함께 구현
- close #153 
  - 로그인 API 구현
- close #166 
  - 로그인해서 받아온 UID를 UserDefault에 저장

### 참고 사항

아래 궁금증은 슬랙에 올렸습니다.
- LoginViewController에 연결하려 했는데 CustomView 관련 궁금증이 있어 파일만 만들었습니다. 
- 유저 정보는 UID만 저장하기로 정한 것으로 아는데 회원가입 후 User 정보를 전부 UserDefault에 저장해서 통일할 필요가 있어보입니다.