### PR TITLE
UserDataSource -> RemoteUserDataSource 변수명 변경

### DIFF
--- a/Mogakco/Sources/Data/DataSources/Protocol/RemoteUserDataSourceProtocol.swift
+++ b/Mogakco/Sources/Data/DataSources/Protocol/RemoteUserDataSourceProtocol.swift
@@ -1,5 +1,5 @@
 //
-//  UserDataSourceProtocol.swift
+//  RemoteUserDataSourceProtocol.swift
 //  Mogakco
 //
 //  Created by 김범수 on 2022/11/21.
@@ -8,6 +8,6 @@
 
 import RxSwift
 
-protocol UserDataSourceProtocol {
+protocol RemoteUserDataSourceProtocol {
     func user(request: UserRequestDTO) -> Observable<UserResponseDTO>
 }

--- a/Mogakco/Sources/Data/DataSources/Remote/RemoteUserDataSource.swift
+++ b/Mogakco/Sources/Data/DataSources/Remote/RemoteUserDataSource.swift
@@ -1,5 +1,5 @@
 //
-//  UserDataSource.swift
+//  RemoteUserDataSource.swift
 //  Mogakco
 //
 //  Created by 김범수 on 2022/11/21.
@@ -9,7 +9,7 @@
 import Alamofire
 import RxSwift
 
-struct UserDataSource: UserDataSourceProtocol {
+struct RemoteUserDataSource: RemoteUserDataSourceProtocol {
     let provider: ProviderProtocol
     
     init(provider: ProviderProtocol) {

--- a/Mogakco/Sources/Data/Repositories/UserRepository.swift
+++ b/Mogakco/Sources/Data/Repositories/UserRepository.swift
@@ -28,6 +28,8 @@ struct UserRepository: UserRepositoryProtocol {
     
     func save(userUID: String) -> Observable<Void> {
         return localUserDataSource.saveUID(userUID: userUID)
+    }
+    
     func user(id: String) -> Observable<User> {
         let request = UserRequestDTO(id: id)
         return retmoteUserDataSource.user(request: request)

--- a/Mogakco/Sources/Data/Repositories/UserRepository.swift
+++ b/Mogakco/Sources/Data/Repositories/UserRepository.swift
@@ -11,15 +11,15 @@ import RxSwift
 struct UserRepository: UserRepositoryProtocol {
 
     private var localUserDataSource: LocalUserDataSourceProtocol
-    private var userDataSource: UserDataSourceProtocol
+    private var retmoteUserDataSource: RemoteUserDataSourceProtocol
     private let disposeBag = DisposeBag()
     
     init(
         localUserDataSource: LocalUserDataSourceProtocol,
-        userDataSource: UserDataSourceProtocol
+        retmoteUserDataSource: RemoteUserDataSourceProtocol
     ) {
         self.localUserDataSource = localUserDataSource
-        self.userDataSource = userDataSource
+        self.retmoteUserDataSource = retmoteUserDataSource
     }
 
     func save(user: User) -> Observable<Void> {
@@ -30,7 +30,7 @@ struct UserRepository: UserRepositoryProtocol {
         return localUserDataSource.saveUID(userUID: userUID)
     func user(id: String) -> Observable<User> {
         let request = UserRequestDTO(id: id)
-        return userDataSource.user(request: request)
+        return retmoteUserDataSource.user(request: request)
             .map { $0.toDomain() }
     }
     

--- a/Mogakco/Sources/Domain/UseCases/LoginUseCase.swift
+++ b/Mogakco/Sources/Domain/UseCases/LoginUseCase.swift
@@ -25,8 +25,6 @@ struct LoginUseCase: LoginUseCaseProtocol {
     }
     
     func login(emailLoginData: EmailLoginData) -> Observable<Void> {
-        let isLoginSuccess = PublishSubject<Void>()
-        
         return authRepository.login(emailLoginData: emailLoginData)
             .flatMap { userRepository.save(userUID: $0) }
     }

--- a/Mogakco/Sources/Presentation/Common/Coordinator/ProfileTabCoordinator.swift
+++ b/Mogakco/Sources/Presentation/Common/Coordinator/ProfileTabCoordinator.swift
@@ -28,7 +28,7 @@ final class ProfileTabCoordinator: Coordinator, ProfileTabCoordinatorProtocol {
             profileUseCase: ProfileUseCase(
                 userRepository: UserRepository(
                     localUserDataSource: UserDefaultsUserDataSource(),
-                    userDataSource: UserDataSource(provider: Provider.default)
+                    retmoteUserDataSource: RemoteUserDataSource(provider: Provider.default)
                 )
             )
         )


### PR DESCRIPTION
### PR Type

- [ ]  기능 추가 🔨
- [ ]  버그 수정 🐞
- [x]  리팩토링 🚧
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [ ]  테스트 🔍
 

### Related Issue(작업 내용)

- resolve #169 
    - UserDataSource -> RemoteUserDataSource 변수명 변경
    - UserDataSourceProtocol -> RemoteUserDataSourceProtocol 변수명 변경
- UserRepository 괄호 오류 수정

### 참고 사항
[리뷰](https://github.com/boostcampwm-2022/iOS04-Mogakco/pull/160#discussion_r1028251011)중 UserDataSouce의 Local, Remote 간의 변수명 구분이 필요하다고 생각되어 변수명을 변경하였습니다

