### PR TITLE
프로필 편집 기능 구현

### DIFF
--- a/Mogakco/Sources/Data/DataMapping/EditProfileRequestDTO.swift
+++ b/Mogakco/Sources/Data/DataMapping/EditProfileRequestDTO.swift
@@ -1,0 +1,34 @@
+//
+//  EditProfileRequestDTO.swift
+//  Mogakco
+//
+//  Created by 김범수 on 2022/11/22.
+//  Copyright © 2022 Mogakco. All rights reserved.
+//
+
+import Foundation
+
+struct EditProfileRequestDTO: Encodable {
+    private let name: StringValue
+    private let introduce: StringValue
+    
+    private enum RootKey: String, CodingKey {
+        case fields
+    }
+    
+    private enum FieldKeys: String, CodingKey {
+        case name, introduce
+    }
+    
+    init(name: String, introduce: String) {
+        self.name = StringValue(value: name)
+        self.introduce = StringValue(value: introduce)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: RootKey.self)
+        var fieldContainer = container.nestedContainer(keyedBy: FieldKeys.self, forKey: .fields)
+        try fieldContainer.encode(self.name, forKey: .name)
+        try fieldContainer.encode(self.introduce, forKey: .introduce)
+    }
+}

--- a/Mogakco/Sources/Data/DataSources/Protocol/RemoteUserDataSourceProtocol.swift
+++ b/Mogakco/Sources/Data/DataSources/Protocol/RemoteUserDataSourceProtocol.swift
@@ -10,4 +10,5 @@ import RxSwift
 
 protocol RemoteUserDataSourceProtocol {
     func user(request: UserRequestDTO) -> Observable<UserResponseDTO>
+    func editProfile(id: String, request: EditProfileRequestDTO) -> Observable<UserResponseDTO>
 }

--- a/Mogakco/Sources/Data/DataSources/Remote/RemoteUserDataSource.swift
+++ b/Mogakco/Sources/Data/DataSources/Remote/RemoteUserDataSource.swift
@@ -19,10 +19,15 @@ struct RemoteUserDataSource: RemoteUserDataSourceProtocol {
     func user(request: UserRequestDTO) -> Observable<UserResponseDTO> {
         return provider.request(UserTarget.user(request))
     }
+    
+    func editProfile(id: String, request: EditProfileRequestDTO) -> Observable<UserResponseDTO> {
+        return provider.request(UserTarget.editProfile(id, request))
+    }
 }
 
 enum UserTarget {
     case user(UserRequestDTO)
+    case editProfile(String, EditProfileRequestDTO)
 }
 
 extension UserTarget: TargetType {
@@ -34,22 +39,23 @@ extension UserTarget: TargetType {
         switch self {
         case .user:
             return .get
+        case .editProfile:
+            return .patch
         }
     }
     
     var header: HTTPHeaders {
-        switch self {
-        case .user:
-            return [
-                "Content-Type": "application/json"
-            ]
-        }
+        return [
+            "Content-Type": "application/json"
+        ]
     }
     
     var path: String {
         switch self {
-        case .user(let request):
+        case let .user(request):
             return "/\(request.id)"
+        case let .editProfile(id, _):
+            return "/\(id)/?updateMask.fieldPaths=name&updateMask.fieldPaths=introduce"
         }
     }
     
@@ -57,13 +63,12 @@ extension UserTarget: TargetType {
         switch self {
         case .user:
             return nil
+        case let .editProfile(_, request):
+            return .body(request)
         }
     }
     
     var encoding: ParameterEncoding {
-        switch self {
-        case .user:
-            return JSONEncoding.default
-        }
+        return JSONEncoding.default
     }
 }

--- a/Mogakco/Sources/Data/Repositories/UserRepository.swift
+++ b/Mogakco/Sources/Data/Repositories/UserRepository.swift
@@ -39,4 +39,11 @@ struct UserRepository: UserRepositoryProtocol {
     func load() -> Observable<User> {
         return localUserDataSource.load()
     }
+    
+    func editProfile(id: String, name: String, introduce: String) -> Observable<User> {
+        let request = EditProfileRequestDTO(name: name, introduce: introduce)
+        return retmoteUserDataSource.editProfile(id: id, request: request)
+            .map { $0.toDomain() }
+    }
 }
+ 

--- a/Mogakco/Sources/Domain/Repositories/UserRepositoryProtocol.swift
+++ b/Mogakco/Sources/Domain/Repositories/UserRepositoryProtocol.swift
@@ -13,4 +13,5 @@ protocol UserRepositoryProtocol {
     func save(userUID: String) -> Observable<Void>
     func user(id: String) -> Observable<User>
     func load() -> Observable<User>
+    func editProfile(id: String, name: String, introduce: String) -> Observable<User>
 }

--- a/Mogakco/Sources/Domain/UseCases/EditProfileUseCase.swift
+++ b/Mogakco/Sources/Domain/UseCases/EditProfileUseCase.swift
@@ -1,0 +1,27 @@
+//
+//  EditProfileUseCase.swift
+//  Mogakco
+//
+//  Created by 김범수 on 2022/11/22.
+//  Copyright © 2022 Mogakco. All rights reserved.
+//
+
+import RxSwift
+
+struct EditProfileUseCase: EditProfileUseCaseProtocol {
+
+    private let userRepository: UserRepositoryProtocol
+    private let disposeBag = DisposeBag()
+    
+    init(userRepository: UserRepositoryProtocol) {
+        self.userRepository = userRepository
+    }
+    
+    func editProfile(name: String, introduce: String) -> Observable<Void> {
+        return userRepository
+            .load()
+            .compactMap { $0.id }
+            .flatMap { userRepository.editProfile(id: $0, name: name, introduce: introduce) }
+            .flatMap { userRepository.save(user: $0) }
+    }
+}

--- a/Mogakco/Sources/Domain/UseCases/Protocol/EditProfileUseCaseProtocol.swift
+++ b/Mogakco/Sources/Domain/UseCases/Protocol/EditProfileUseCaseProtocol.swift
@@ -1,0 +1,13 @@
+//
+//  EditProfileUseCaseProtocol.swift
+//  Mogakco
+//
+//  Created by 김범수 on 2022/11/22.
+//  Copyright © 2022 Mogakco. All rights reserved.
+//
+
+import RxSwift
+
+protocol EditProfileUseCaseProtocol {
+    func editProfile(name: String, introduce: String) -> Observable<Void>
+}

--- a/Mogakco/Sources/Network/TargetType.swift
+++ b/Mogakco/Sources/Network/TargetType.swift
@@ -22,7 +22,9 @@ protocol TargetType: URLRequestConvertible {
 extension TargetType {
     func asURLRequest() throws -> URLRequest {
         let url = try baseURL.asURL()
-        var urlRequest = try URLRequest(url: url.appendingPathComponent(path), method: method)
+        // var urlRequest = try URLRequest(url: url.appendingPathComponent(path), method: method)
+        // appendingPathComponent 사용 시 path 내 ?를 %3f로 인식하여 임시 처리
+        var urlRequest = try URLRequest(url: url.absoluteString + path, method: method)
         urlRequest.headers = header
 
         switch parameters {

--- a/Mogakco/Sources/Presentation/Common/Coordinator/AdditionalSignupCoordinator.swift
+++ b/Mogakco/Sources/Presentation/Common/Coordinator/AdditionalSignupCoordinator.swift
@@ -33,13 +33,13 @@ final class AdditionalSignupCoordinator: Coordinator, AdditionalSignupCoordinato
             localUserDataSource: UserDefaultsUserDataSource(),
             retmoteUserDataSource: RemoteUserDataSource(provider: Provider.default)
         )
-        let viewModel = CreateProfiileViewModel(
+        let viewModel = EditProfiileViewModel(
             type: .create,
             coordinator: self,
             profileUseCase: ProfileUseCase(userRepository: userRepository),
             editProfileUseCase: EditProfileUseCase(userRepository: userRepository)
         )
-        let viewController = CreateProfileViewController(viewModel: viewModel)
+        let viewController = EditProfileViewController(viewModel: viewModel)
         navigationController.pushViewController(viewController, animated: true)
     }
     

--- a/Mogakco/Sources/Presentation/Common/Coordinator/AdditionalSignupCoordinator.swift
+++ b/Mogakco/Sources/Presentation/Common/Coordinator/AdditionalSignupCoordinator.swift
@@ -29,7 +29,16 @@ final class AdditionalSignupCoordinator: Coordinator, AdditionalSignupCoordinato
     }
     
     func showCreateProfile() {
-        let viewModel = CreateProfiileViewModel(coordinator: self)
+        let userRepository = UserRepository(
+            localUserDataSource: UserDefaultsUserDataSource(),
+            retmoteUserDataSource: RemoteUserDataSource(provider: Provider.default)
+        )
+        let viewModel = CreateProfiileViewModel(
+            type: .create,
+            coordinator: self,
+            profileUseCase: ProfileUseCase(userRepository: userRepository),
+            editProfileUseCase: EditProfileUseCase(userRepository: userRepository)
+        )
         let viewController = CreateProfileViewController(viewModel: viewModel)
         navigationController.pushViewController(viewController, animated: true)
     }

--- a/Mogakco/Sources/Presentation/Common/Coordinator/ProfileTabCoordinator.swift
+++ b/Mogakco/Sources/Presentation/Common/Coordinator/ProfileTabCoordinator.swift
@@ -41,13 +41,13 @@ final class ProfileTabCoordinator: Coordinator, ProfileTabCoordinatorProtocol {
             localUserDataSource: UserDefaultsUserDataSource(),
             retmoteUserDataSource: RemoteUserDataSource(provider: Provider.default)
         )
-        let viewModel = CreateProfiileViewModel(
+        let viewModel = EditProfiileViewModel(
             type: .edit,
             coordinator: self,
             profileUseCase: ProfileUseCase(userRepository: userRepository),
             editProfileUseCase: EditProfileUseCase(userRepository: userRepository)
         )
-        let viewController = CreateProfileViewController(viewModel: viewModel)
+        let viewController = EditProfileViewController(viewModel: viewModel)
         navigationController.pushViewController(viewController, animated: false)
     }
 }

--- a/Mogakco/Sources/Presentation/Common/Coordinator/ProfileTabCoordinator.swift
+++ b/Mogakco/Sources/Presentation/Common/Coordinator/ProfileTabCoordinator.swift
@@ -37,7 +37,16 @@ final class ProfileTabCoordinator: Coordinator, ProfileTabCoordinatorProtocol {
     }
     
     func showEditProfile() {
-        let viewModel = CreateProfiileViewModel(coordinator: self)
+        let userRepository = UserRepository(
+            localUserDataSource: UserDefaultsUserDataSource(),
+            retmoteUserDataSource: RemoteUserDataSource(provider: Provider.default)
+        )
+        let viewModel = CreateProfiileViewModel(
+            type: .edit,
+            coordinator: self,
+            profileUseCase: ProfileUseCase(userRepository: userRepository),
+            editProfileUseCase: EditProfileUseCase(userRepository: userRepository)
+        )
         let viewController = CreateProfileViewController(viewModel: viewModel)
         navigationController.pushViewController(viewController, animated: false)
     }

--- a/Mogakco/Sources/Presentation/Common/Coordinator/Protocol/Coordinator.swift
+++ b/Mogakco/Sources/Presentation/Common/Coordinator/Protocol/Coordinator.swift
@@ -19,4 +19,8 @@ extension Coordinator {
     func finish(_ child: Coordinator) {
         childCoordinators = childCoordinators.filter { !($0 === child) }
     }
+    
+    func pop(animated: Bool) {
+        navigationController.popViewController(animated: animated)
+    }
 }

--- a/Mogakco/Sources/Presentation/Profile/ViewController/CreateProfileViewController.swift
+++ b/Mogakco/Sources/Presentation/Profile/ViewController/CreateProfileViewController.swift
@@ -35,7 +35,7 @@ final class CreateProfileViewController: ViewController {
         $0.placeholder = "이름을 입력해주세요."
     }
     
-    private let introuceCountTextField = CountTextView().then {
+    private let introuceCountTextView = CountTextView().then {
         $0.title = "소개"
         $0.maxCount = 100
         $0.placeholder = "자신을 소개해주세요."
@@ -80,7 +80,7 @@ final class CreateProfileViewController: ViewController {
     override func bind() {
         let input = CreateProfiileViewModel.Input(
             name: nameCountTextField.rx.text.orEmpty.asObservable(),
-            introduce: introuceCountTextField.rx.text.orEmpty.asObservable(),
+            introduce: introuceCountTextView.rx.text.orEmpty.asObservable(),
             selectedProfileImage: selectedProfileImage.asObservable(),
             completeButtonTapped: completeButton.rx.tap.asObservable()
         )
@@ -93,8 +93,24 @@ final class CreateProfileViewController: ViewController {
             })
             .disposed(by: disposeBag)
         
-        output.profileImage
+        output.originName
+            .asDriver(onErrorJustReturn: "")
+            .drive(nameCountTextField.rx.text)
+            .disposed(by: disposeBag)
+        
+        output.originIntroduce
+            .asDriver(onErrorJustReturn: "")
+            .drive(introuceCountTextView.rx.text)
+            .disposed(by: disposeBag)
+        
+        output.originProfileImage
+            .asDriver(onErrorJustReturn: .init())
             .drive(roundProfileImageView.rx.image)
+            .disposed(by: disposeBag)
+        
+        output.inputValidation
+            .asDriver(onErrorJustReturn: false)
+            .drive(completeButton.rx.isEnabled)
             .disposed(by: disposeBag)
         
         RxKeyboard.instance.visibleHeight
@@ -159,8 +175,8 @@ final class CreateProfileViewController: ViewController {
     }
     
     private func layoutIntrouceCountTextField() {
-        contentView.addSubview(introuceCountTextField)
-        introuceCountTextField.snp.makeConstraints {
+        contentView.addSubview(introuceCountTextView)
+        introuceCountTextView.snp.makeConstraints {
             $0.leading.trailing.equalToSuperview().inset(16.0)
             $0.top.equalTo(nameCountTextField.snp.bottom).offset(8.0)
             $0.height.equalTo(240.0)
@@ -172,7 +188,7 @@ final class CreateProfileViewController: ViewController {
         contentView.addSubview(marginView)
         marginView.snp.makeConstraints {
             $0.leading.trailing.bottom.equalToSuperview()
-            $0.top.equalTo(introuceCountTextField.snp.bottom)
+            $0.top.equalTo(introuceCountTextView.snp.bottom)
         }
     }
     

--- a/Mogakco/Sources/Presentation/Profile/ViewController/EditProfileViewController.swift
+++ b/Mogakco/Sources/Presentation/Profile/ViewController/EditProfileViewController.swift
@@ -1,5 +1,5 @@
 //
-//  CreateProfileViewController.swift
+//  EditProfileViewController.swift
 //  Mogakco
 //
 //  Created by 김범수 on 2022/11/16.
@@ -12,7 +12,7 @@ import RxCocoa
 import RxSwift
 import RxKeyboard
 
-final class CreateProfileViewController: ViewController {
+final class EditProfileViewController: ViewController {
     
     private let scrollView = UIScrollView().then {
         $0.showsVerticalScrollIndicator = false
@@ -47,11 +47,11 @@ final class CreateProfileViewController: ViewController {
         $0.setTitle("완료", for: .normal)
     }
     
-    private var viewModel: CreateProfiileViewModel
+    private var viewModel: EditProfiileViewModel
     private let imagePicker = UIImagePickerController()
     private let selectedProfileImage = PublishRelay<UIImage>()
     
-    init(viewModel: CreateProfiileViewModel) {
+    init(viewModel: EditProfiileViewModel) {
         self.viewModel = viewModel
         super.init(nibName: nil, bundle: nil)
     }
@@ -78,7 +78,7 @@ final class CreateProfileViewController: ViewController {
     }
     
     override func bind() {
-        let input = CreateProfiileViewModel.Input(
+        let input = EditProfiileViewModel.Input(
             name: nameCountTextField.rx.text.orEmpty.asObservable(),
             introduce: introuceCountTextView.rx.text.orEmpty.asObservable(),
             selectedProfileImage: selectedProfileImage.asObservable(),
@@ -203,7 +203,7 @@ final class CreateProfileViewController: ViewController {
 
 // MARK: Picker
 
-private extension CreateProfileViewController {
+private extension EditProfileViewController {
     func configureImagePicker() {
         imagePicker.allowsEditing = true
         imagePicker.delegate = self
@@ -216,7 +216,7 @@ private extension CreateProfileViewController {
 
 // MARK: Picker Delegate
 
-extension CreateProfileViewController: UIImagePickerControllerDelegate, UINavigationControllerDelegate {
+extension EditProfileViewController: UIImagePickerControllerDelegate, UINavigationControllerDelegate {
     func imagePickerController(
         _ picker: UIImagePickerController,
         didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]

--- a/Mogakco/Sources/Presentation/Profile/ViewModel/CreateProfiileViewModel.swift
+++ b/Mogakco/Sources/Presentation/Profile/ViewModel/CreateProfiileViewModel.swift
@@ -13,6 +13,10 @@ import RxSwift
 
 final class CreateProfiileViewModel: ViewModel {
     
+    enum ProfileType {
+        case create, edit
+    }
+    
     struct Input {
         let name: Observable<String>
         let introduce: Observable<String>
@@ -21,36 +25,103 @@ final class CreateProfiileViewModel: ViewModel {
     }
     
     struct Output {
-        let profileImage: Driver<UIImage>
+        let originName: Observable<String>
+        let originIntroduce: Observable<String>
+        let originProfileImage: Observable<UIImage>
+        let inputValidation: Observable<Bool>
     }
     
     var disposeBag = DisposeBag()
-    weak var coordinator: Coordinator?
+    private let type: ProfileType
+    private weak var coordinator: Coordinator?
+    private let profileUseCase: ProfileUseCase
+    private let editProfileUseCase: EditProfileUseCase
     
-    init(coordinator: Coordinator) {
+    init(
+        type: ProfileType,
+        coordinator: Coordinator,
+        profileUseCase: ProfileUseCase,
+        editProfileUseCase: EditProfileUseCase
+    ) {
+        self.type = type
         self.coordinator = coordinator
+        self.profileUseCase = profileUseCase
+        self.editProfileUseCase = editProfileUseCase
     }
     
     func transform(input: Input) -> Output {
+        let profileType = BehaviorSubject<ProfileType>(value: type)
+        let user = BehaviorSubject<User?>(value: nil)
+  
+        let name = Observable.merge(
+            user.compactMap { $0?.name },
+            input.name
+        )
         
-        input
+        let introduce = Observable.merge(
+            user.compactMap { $0?.introduce },
+            input.introduce
+        )
+        
+        let profileImage = Observable.merge(
+            // user.compactMap { $0?.profileImage },
+            input.selectedProfileImage
+        )
+        
+        let inputValidation = name.map { (2...10).contains($0.count) }
+        
+        profileType
+            .filter { $0 == .edit }
+            .withUnretained(self)
+            .flatMap { $0.0.profileUseCase.profile() }
+            .subscribe(onNext: {
+                user.onNext($0)
+            })
+            .disposed(by: disposeBag)
+        
+        let profileEdit = input
             .completeButtonTapped
+            .withLatestFrom(profileType)
+            .filter { $0 == .edit }
+        
+        profileEdit
             .withLatestFrom(
-                Observable.combineLatest(
-                    input.name,
-                    input.introduce,
-                    input.selectedProfileImage
-                )
+                Observable.combineLatest(name, introduce, profileImage)
             )
+            .flatMap { name, introduce, _ in
+                self.editProfileUseCase.editProfile(name: name, introduce: introduce)
+            }
             .subscribe(onNext: { _ in
-                // TODO: UseCase - CreateProfile
-                // TODO: AppDelegate - Push
+                print("Edit Success")
+                // TODO: Pop
+            }, onError: { error in
+                print("Edit Error \(error.localizedDescription)")
+            })
+            .disposed(by: disposeBag)
+        
+        let profileCreate = input
+            .completeButtonTapped
+            .withLatestFrom(profileType)
+            .filter { $0 == .create }
+        
+        profileCreate
+            .withLatestFrom(Observable.combineLatest(
+                input.name,
+                input.introduce,
+                input.selectedProfileImage
+            ))
+            .subscribe(onNext: { _ in
                 if let coordinator = self.coordinator as? AdditionalSignupCoordinator {
                     coordinator.showLanguage()
                 }
             })
             .disposed(by: disposeBag)
         
-        return Output(profileImage: input.selectedProfileImage.asDriver(onErrorJustReturn: UIImage()))
+        return Output(
+            originName: user.compactMap { $0?.name },
+            originIntroduce: user.compactMap { $0?.introduce },
+            originProfileImage: profileImage.take(1),
+            inputValidation: inputValidation.asObservable()
+        )
     }
 }


### PR DESCRIPTION
### PR Type

- [x]  기능 추가 🔨
- [ ]  버그 수정 🐞
- [ ]  리팩토링 🚧
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [ ]  테스트 🔍
 

### Related Issue(작업 내용)

- resolves #19 
    - UserDataSource, UserRepository 내 프로필 편집 API 구현
- resolves #18 
    - EditProfileUseCase 내 프로필 편집 기능 구현
- resolves #56 
  - 프로필 편집
    - 유저 기존 데이터 바인딩
    - 프로필 편집 로직 및 성공 시 pop
  - 프로필 생성
    - 완료 버튼 클릭 시 언어 선택 화면 이동
  - 공통
    - 이름 2~10자로 유효성 검사

### 참고 사항
- 프로필 이미지 관련해서는 아직 처리되지 않아 [이슈](https://github.com/boostcampwm-2022/iOS04-Mogakco/compare/feat/edit-profile-api?expand=1#workspaces/ios-team-6368c8380df2fad06bda2118/board?labels=%EB%B2%94%EC%88%98)를 따로 생성해두겠습니다.
- 파이어베이스에 Request Body를 보낼 시 EditProfileRequestDTO의 encode 메소드를 참고해서 구현하시면 편할겁니당!!

### Screenshots(Optional)
- 변경 전
<img src="https://user-images.githubusercontent.com/73675540/203236918-e9fb57c4-7195-456b-bf34-cf36a1fd7c9b.png" width="50%">

- 변경 후
<img src="https://user-images.githubusercontent.com/73675540/203236929-f9596bc2-729f-4123-a3d6-351cb0e9847a.png" width="50%">
