### PR TITLE
TextView placeholder 레이블 히든 로직 수정

### DIFF
--- a/Mogakco/Sources/Presentation/Common/View/TextView.swift
+++ b/Mogakco/Sources/Presentation/Common/View/TextView.swift
@@ -80,19 +80,10 @@ final class TextView: UITextView {
     }
     
     private func bind() {
-        self.rx.didBeginEditing
-            .subscribe(onNext: { [weak self] in
-                self?.label.isHidden = true
-            })
-            .disposed(by: disposeBag)
-
-        self.rx.didEndEditing
-            .filter { [weak self] in
-                self?.text.isEmpty ?? true
-            }
-            .subscribe(onNext: { [weak self] in
-                self?.label.isHidden = false
-            })
+        self.rx.text
+            .orEmpty
+            .map { !$0.isEmpty }
+            .bind(to: label.rx.isHidden)
             .disposed(by: disposeBag)
     }
 }


### PR DESCRIPTION
### PR Type

- [ ]  기능 추가 🔨
- [X]  버그 수정 🐞
- [ ]  리팩토링 🚧
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [ ]  테스트 🔍
 

### Related Issue(작업 내용)

> 이슈 번호와 구현 내용 및 작업 했던 내역을 입력해주세요!
> 
- close #187 
    - didBeginEditing, didEndEditing 이벤트를 구독해서 placeholder 레이블을 히든 처리하면
      TextView에 초기값을 줬을 때 placeholder 레이블이 사라지지 않는 문제가 있어서 
      text 이벤트를 구독해서 히든처리하도록 변경했습니다.

### Screenshots
#### 수정 전
https://user-images.githubusercontent.com/109145755/203331240-864a81b8-166b-411c-8cdc-b079628496e0.mp4

#### 수정 후
https://user-images.githubusercontent.com/109145755/203331230-13a1f0f0-3a09-473d-90ee-d68ec0824b15.mp4


