### PR TITLE
프로필 화면 유저 타입에 따른 분기 처리

### DIFF
--- a/Mogakco/Sources/Domain/UseCases/Protocol/UserUseCaseProtocol.swift
+++ b/Mogakco/Sources/Domain/UseCases/Protocol/UserUseCaseProtocol.swift
@@ -10,4 +10,5 @@ import RxSwift
 
 protocol UserUseCaseProtocol {
     func user(id: String) -> Observable<User>
+    func myProfile() -> Observable<User>
 }

--- a/Mogakco/Sources/Domain/UseCases/UserUseCase.swift
+++ b/Mogakco/Sources/Domain/UseCases/UserUseCase.swift
@@ -20,4 +20,13 @@ struct UserUseCase: UserUseCaseProtocol {
     func user(id: String) -> Observable<User> {
         return userRepository.user(id: id)
     }
+    
+    func myProfile() -> Observable<User> {
+        return userRepository.load()
+            .compactMap { $0.id }
+            .flatMap { userRepository.user(id: $0) }
+            .do(onNext: {
+                _ = userRepository.save(user: $0)
+            })
+    }
 }

--- a/Mogakco/Sources/Presentation/Chat/ViewModel/ChatListViewModel.swift
+++ b/Mogakco/Sources/Presentation/Chat/ViewModel/ChatListViewModel.swift
@@ -22,11 +22,11 @@ final class ChatListViewModel: ViewModel {
     }
     
     var disposeBag = DisposeBag()
-    private weak var coordinator: ChatTabCoordinator?
+    private weak var coordinator: ChatTabCoordinatorProtocol?
     private let chatRoomListUseCase: ChatRoomListUseCaseProtocol
  
     init(
-        coordinator: ChatTabCoordinator,
+        coordinator: ChatTabCoordinatorProtocol,
         chatRoomListUseCase: ChatRoomListUseCaseProtocol
     ) {
         self.coordinator = coordinator

--- a/Mogakco/Sources/Presentation/Common/Coordinator/ProfileTabCoordinator.swift
+++ b/Mogakco/Sources/Presentation/Common/Coordinator/ProfileTabCoordinator.swift
@@ -24,8 +24,9 @@ final class ProfileTabCoordinator: Coordinator, ProfileTabCoordinatorProtocol {
     
     func showProfile() {
         let viewModel = ProfileViewModel(
+            type: .current,
             coordinator: self,
-            profileUseCase: ProfileUseCase(
+            userUseCase: UserUseCase(
                 userRepository: UserRepository(
                     localUserDataSource: UserDefaultsUserDataSource(),
                     remoteUserDataSource: RemoteUserDataSource(provider: Provider.default)

--- a/Mogakco/Sources/Presentation/Common/Coordinator/ProfileTabCoordinator.swift
+++ b/Mogakco/Sources/Presentation/Common/Coordinator/ProfileTabCoordinator.swift
@@ -51,4 +51,10 @@ final class ProfileTabCoordinator: Coordinator, ProfileTabCoordinatorProtocol {
         let viewController = EditProfileViewController(viewModel: viewModel)
         navigationController.pushViewController(viewController, animated: false)
     }
+    
+    func showChat() {
+    }
+    
+    func showSelectHashtag(kindHashtag: KindHashtag) {
+    }
 }

--- a/Mogakco/Sources/Presentation/Common/Coordinator/Protocol/ProfileTabCoordinatorProtocol.swift
+++ b/Mogakco/Sources/Presentation/Common/Coordinator/Protocol/ProfileTabCoordinatorProtocol.swift
@@ -11,4 +11,6 @@ import Foundation
 protocol ProfileTabCoordinatorProtocol: AnyObject {
     func showProfile()
     func showEditProfile()
+    func showChat()
+    func showSelectHashtag(kindHashtag: KindHashtag)
 }

--- a/Mogakco/Sources/Presentation/Profile/View/HashtagListView.swift
+++ b/Mogakco/Sources/Presentation/Profile/View/HashtagListView.swift
@@ -13,7 +13,7 @@ import RxSwift
 
 final class HashtagListView: UIView {
     
-    private let typeLabel = UILabel().then {
+    let titleLabel = UILabel().then {
         $0.font = UIFont.mogakcoFont.smallBold
         $0.text = "해시태크"
         $0.textColor = UIColor.mogakcoColor.typographyPrimary
@@ -78,7 +78,7 @@ final class HashtagListView: UIView {
     }
  
     private func createLabelStackView() -> UIStackView {
-        let arrangeSubviews = [typeLabel, editButton]
+        let arrangeSubviews = [titleLabel, editButton]
         return UIStackView(arrangedSubviews: arrangeSubviews).then {
             $0.axis = .horizontal
             $0.layoutMargins = .init(top: 0.0, left: 16.0, bottom: 0.0, right: 16.0)

--- a/Mogakco/Sources/Presentation/Profile/View/HashtagListView.swift
+++ b/Mogakco/Sources/Presentation/Profile/View/HashtagListView.swift
@@ -19,7 +19,7 @@ final class HashtagListView: UIView {
         $0.textColor = UIColor.mogakcoColor.typographyPrimary
     }
     
-    private let editButton = UIButton().then {
+    let editButton = UIButton().then {
         $0.addShadow(offset: .init(width: 5.0, height: 5.0))
         $0.layer.cornerRadius = 8.0
         $0.setTitle("편집", for: .normal)

--- a/Mogakco/Sources/Presentation/Profile/View/ProfileView.swift
+++ b/Mogakco/Sources/Presentation/Profile/View/ProfileView.swift
@@ -38,7 +38,7 @@ final class ProfileView: UIView {
         $0.textAlignment = .left
     }
     
-    private let chatButton = UIButton().then {
+    let chatButton = UIButton().then {
         $0.addShadow(offset: .init(width: 5.0, height: 5.0))
         $0.layer.cornerRadius = 12.0
         $0.setTitle("채팅", for: .normal)

--- a/Mogakco/Sources/Presentation/Profile/View/ProfileView.swift
+++ b/Mogakco/Sources/Presentation/Profile/View/ProfileView.swift
@@ -16,7 +16,7 @@ final class ProfileView: UIView {
         }
     }
     
-    private let roundLanguageImageView = RoundProfileImageView(45.0).then {
+    let roundLanguageImageView = RoundProfileImageView(45.0).then {
         $0.snp.makeConstraints {
             $0.size.equalTo(45.0)
         }
@@ -25,14 +25,12 @@ final class ProfileView: UIView {
     
     let nameLabel = UILabel().then {
         $0.font = UIFont.mogakcoFont.smallBold
-        $0.text = "옹심이"
         $0.textColor = .mogakcoColor.typographyPrimary
         $0.textAlignment = .left
     }
     
     let introduceLabel = UILabel().then {
         $0.font = UIFont.mogakcoFont.caption
-        $0.text = "안녕하세요!! iOS 개발자 옹심이입니다."
         $0.textColor = .mogakcoColor.typographySecondary
         $0.numberOfLines = 0
         $0.textAlignment = .left

--- a/Mogakco/Sources/Presentation/Profile/ViewController/ProfileViewController.swift
+++ b/Mogakco/Sources/Presentation/Profile/ViewController/ProfileViewController.swift
@@ -24,12 +24,12 @@ final class ProfileViewController: ViewController {
     }
     
     private lazy var contentStackView = UIStackView(arrangedSubviews: [
-        self.headerView,
         self.profileView,
         self.languageListView,
         self.careerListView,
         self.categoryListView,
-        self.studyRatingListView
+        self.studyRatingListView,
+        self.marginView
     ]).then {
         $0.spacing = 4.0
         $0.axis = .vertical
@@ -37,9 +37,6 @@ final class ProfileViewController: ViewController {
     
     private let headerView = TitleHeaderView().then {
         $0.setTitle(Constant.headerViewTitle)
-        $0.snp.makeConstraints {
-            $0.height.equalTo(Constant.headerViewHeight)
-        }
     }
     
     private let profileView = ProfileView().then {
@@ -69,6 +66,12 @@ final class ProfileViewController: ViewController {
     private let studyRatingListView = StudyRatingListView().then {
         $0.snp.makeConstraints {
             $0.height.equalTo(Constant.studyRatingListView)
+        }
+    }
+    
+    private let marginView = UIView().then {
+        $0.snp.makeConstraints {
+            $0.height.equalTo(200.0)
         }
     }
     
@@ -145,18 +148,28 @@ final class ProfileViewController: ViewController {
     }
     
     override func layout() {
+        layoutHeaderView()
         layoutScrollView()
+    }
+    
+    private func layoutHeaderView() {
+        view.addSubview(headerView)
+        headerView.snp.makeConstraints {
+            $0.leading.top.trailing.equalTo(view.safeAreaLayoutGuide)
+            $0.height.equalTo(Constant.headerViewHeight)
+        }
     }
     
     private func layoutScrollView() {
         view.addSubview(scrollView)
         scrollView.snp.makeConstraints {
-            $0.edges.equalToSuperview()
+            $0.top.equalTo(headerView.snp.bottom)
+            $0.leading.trailing.bottom.equalToSuperview()
         }
         
         scrollView.addSubview(contentStackView)
         contentStackView.snp.makeConstraints {
-            $0.edges.equalToSuperview()
+            $0.leading.top.trailing.bottom.equalToSuperview()
             $0.width.equalToSuperview()
         }
     }

--- a/Mogakco/Sources/Presentation/Profile/ViewController/ProfileViewController.swift
+++ b/Mogakco/Sources/Presentation/Profile/ViewController/ProfileViewController.swift
@@ -92,6 +92,35 @@ final class ProfileViewController: ViewController {
         )
         let output = viewModel.transform(input: input)
         
+        output.myProfile
+            .asDriver(onErrorJustReturn: false)
+            .drive(profileView.chatButton.rx.isHidden)
+            .disposed(by: disposeBag)
+        
+        output.myProfile
+            .map { !$0 }
+            .asDriver(onErrorJustReturn: false)
+            .drive(profileView.editProfileButton.rx.isHidden)
+            .disposed(by: disposeBag)
+        
+        output.myProfile
+            .map { !$0 }
+            .asDriver(onErrorJustReturn: false)
+            .drive(languageListView.editButton.rx.isHidden)
+            .disposed(by: disposeBag)
+        
+        output.myProfile
+            .map { !$0 }
+            .asDriver(onErrorJustReturn: false)
+            .drive(careerListView.editButton.rx.isHidden)
+            .disposed(by: disposeBag)
+        
+        output.myProfile
+            .map { !$0 }
+            .asDriver(onErrorJustReturn: false)
+            .drive(categoryListView.editButton.rx.isHidden)
+            .disposed(by: disposeBag)
+        
         output.profileImageURL
             .asDriver(onErrorDriveWith: .empty())
             .drive(profileView.roundProfileImageView.rx.loadImage)

--- a/Mogakco/Sources/Presentation/Profile/ViewModel/ProfileViewModel.swift
+++ b/Mogakco/Sources/Presentation/Profile/ViewModel/ProfileViewModel.swift
@@ -13,11 +13,26 @@ import RxSwift
 
 final class ProfileViewModel: ViewModel {
     
+    enum ProfileType: Equatable {
+        case current
+        case other(User)
+        
+        static func == (lhs: Self, rhs: Self) -> Bool {
+            switch (lhs, rhs) {
+            case (.current, .current), (.other, .other):
+                return true
+            default:
+                return false
+            }
+        }
+    }
+    
     struct Input {
         let editProfileButtonTapped: Observable<Void>
     }
     
     struct Output {
+        let myProfile: Observable<Bool>
         let profileImageURL: Observable<URL>
         let name: Observable<String>
         let introduce: Observable<String>
@@ -25,31 +40,45 @@ final class ProfileViewModel: ViewModel {
         let careers: Observable<[String]>
         let categorys: Observable<[String]>
     }
-    
+
     var disposeBag = DisposeBag()
-    weak var coordinator: ProfileTabCoordinator?
-    let profileUseCase: ProfileUseCase
+    private let type: ProfileType
+    private weak var coordinator: ProfileTabCoordinator?
+    private let userUseCase: UserUseCase
  
     init(
+        type: ProfileType,
         coordinator: ProfileTabCoordinator,
-        profileUseCase: ProfileUseCase
+        userUseCase: UserUseCase
     ) {
+        self.type = type
         self.coordinator = coordinator
-        self.profileUseCase = profileUseCase
+        self.userUseCase = userUseCase
     }
     
     func transform(input: Input) -> Output {
+        let type = BehaviorSubject<ProfileType>(value: type)
+        let myProfile = type
+            .map { $0 == .current }
+        let user = type
+            .withUnretained(self)
+            .flatMap { viewModel, type -> Observable<User> in
+                switch type {
+                case .current:
+                    return viewModel.userUseCase.myProfile()
+                case let .other(user):
+                    return viewModel.userUseCase.user(id: user.id ?? "")
+                }
+            }
+        
         input.editProfileButtonTapped
             .subscribe(onNext: {
                 self.coordinator?.showEditProfile()
             })
             .disposed(by: disposeBag)
         
-        let user = Observable.just(())
-            .withUnretained(self)
-            .flatMap { $0.0.profileUseCase.profile() }
-        
         return Output(
+            myProfile: myProfile.asObservable(),
             profileImageURL: user.compactMap { URL(string: $0.profileImageURLString) },
             name: user.map { $0.name }.asObservable(),
             introduce: user.map { $0.introduce }.asObservable(),


### PR DESCRIPTION
### PR Type

- [x]  기능 추가 🔨
- [ ]  버그 수정 🐞
- [ ]  리팩토링 🚧
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [ ]  테스트 🔍
 

### Related Issue(작업 내용)

- resolve #197 
    - 자신, 타 유저에 따라 프로필 화면에서 분기 처리를 진행하였습니다.
      - 유저 정보 불러오기
      - 채팅, 프로필, 카테고리 편집 버튼 숨김 여부
- 채팅, 카테고리 편집 버튼 클릭 시 화면 이동 로직을 구현하였습니다.
  - 아직 Coordinator 내 로직이 없어 클릭해도 화면이 이동되지는 않습니다.
- 프로필 헤더가 스크롤 시 고정되지 않는 오류를 수정하였습니다.
  

### Screenshots(Optional)
- 순서대로 자신 / 타 유저 화면
<img src="https://user-images.githubusercontent.com/73675540/203469430-90e690db-f237-4cfd-a618-393b910e4c55.png" width="40%"> <img src="https://user-images.githubusercontent.com/73675540/203469439-25a347ee-6b40-418c-afb4-3dada8a52984.png" width="40%"> 

