### PR TITLE
UIViewController Life Cycle을 RxExtension으로 추가

### DIFF
--- a/Mogakco/Sources/Util/Extension/RxUIViewController+LifeCycle.swift
+++ b/Mogakco/Sources/Util/Extension/RxUIViewController+LifeCycle.swift
@@ -1,0 +1,76 @@
+//
+//  RxUIViewController+LifeCycle.swift
+//  Mogakco
+//
+//  Created by 김범수 on 2022/11/24.
+//  Copyright © 2022 Mogakco. All rights reserved.
+//
+
+import UIKit
+
+import RxCocoa
+import RxSwift
+
+public extension Reactive where Base: UIViewController {
+  var viewDidLoad: ControlEvent<Void> {
+    let source = self.methodInvoked(#selector(Base.viewDidLoad)).map { _ in }
+    return ControlEvent(events: source)
+  }
+
+  var viewWillAppear: ControlEvent<Bool> {
+    let source = self.methodInvoked(#selector(Base.viewWillAppear)).map { $0.first as? Bool ?? false }
+    return ControlEvent(events: source)
+  }
+    
+  var viewDidAppear: ControlEvent<Bool> {
+    let source = self.methodInvoked(#selector(Base.viewDidAppear)).map { $0.first as? Bool ?? false }
+    return ControlEvent(events: source)
+  }
+
+  var viewWillDisappear: ControlEvent<Bool> {
+    let source = self.methodInvoked(#selector(Base.viewWillDisappear)).map { $0.first as? Bool ?? false }
+    return ControlEvent(events: source)
+  }
+  var viewDidDisappear: ControlEvent<Bool> {
+    let source = self.methodInvoked(#selector(Base.viewDidDisappear)).map { $0.first as? Bool ?? false }
+    return ControlEvent(events: source)
+  }
+
+  var viewWillLayoutSubviews: ControlEvent<Void> {
+    let source = self.methodInvoked(#selector(Base.viewWillLayoutSubviews)).map { _ in }
+    return ControlEvent(events: source)
+  }
+    
+  var viewDidLayoutSubviews: ControlEvent<Void> {
+    let source = self.methodInvoked(#selector(Base.viewDidLayoutSubviews)).map { _ in }
+    return ControlEvent(events: source)
+  }
+
+  var willMoveToParentViewController: ControlEvent<UIViewController?> {
+    let source = self.methodInvoked(#selector(Base.willMove)).map { $0.first as? UIViewController }
+    return ControlEvent(events: source)
+  }
+    
+  var didMoveToParentViewController: ControlEvent<UIViewController?> {
+    let source = self.methodInvoked(#selector(Base.didMove)).map { $0.first as? UIViewController }
+    return ControlEvent(events: source)
+  }
+
+  var didReceiveMemoryWarning: ControlEvent<Void> {
+    let source = self.methodInvoked(#selector(Base.didReceiveMemoryWarning)).map { _ in }
+    return ControlEvent(events: source)
+  }
+
+  /// Rx observable, triggered when the ViewController appearance state changes (true if the View is being displayed, false otherwise)
+  var isVisible: Observable<Bool> {
+      let viewDidAppearObservable = self.base.rx.viewDidAppear.map { _ in true }
+      let viewWillDisappearObservable = self.base.rx.viewWillDisappear.map { _ in false }
+      return Observable<Bool>.merge(viewDidAppearObservable, viewWillDisappearObservable)
+  }
+
+  /// Rx observable, triggered when the ViewController is being dismissed
+  var isDismissing: ControlEvent<Bool> {
+      let source = self.sentMessage(#selector(Base.dismiss)).map { $0.first as? Bool ?? false }
+      return ControlEvent(events: source)
+  }
+}


### PR DESCRIPTION
### PR Type

- [x]  기능 추가 🔨
- [ ]  버그 수정 🐞
- [ ]  리팩토링 🚧
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [ ]  테스트 🔍
 

### Related Issue(작업 내용)

viewModeld에서 데이터 리로드등의 작업 시 라이프 사이클 이벤트를 받기 위해 간단한 코드라 [RxViewController](https://github.com/devxoul/RxViewController)의 소스를 긁어왔습니다
`rx.viewWillAppear` 와 같은 코드로 이벤트를 받을 수 있습니당!
