### PR TITLE
채팅방 목록 화면 최신 메세지, 읽지 않은 메세지 수 구현

### DIFF
--- a/Mogakco/Sources/Data/DataMapping/ChatResponseDTO.swift
+++ b/Mogakco/Sources/Data/DataMapping/ChatResponseDTO.swift
@@ -12,13 +12,16 @@ struct ChatResponseDTO: Codable {
     private let id: StringValue
     private let userID: StringValue
     private let message: StringValue
+    private let chatRoomID: StringValue
+    private let date: IntegerValue
+    private let readUserIDs: ArrayValue<StringValue>
     
     private enum RootKey: String, CodingKey {
         case fields
     }
     
     private enum FieldKeys: String, CodingKey {
-        case id, userID, message
+        case id, userID, message, chatRoomID, date, readUserIDs
     }
     
     init(from decoder: Decoder) throws {
@@ -27,13 +30,19 @@ struct ChatResponseDTO: Codable {
         self.id = try fieldContainer.decode(StringValue.self, forKey: .id)
         self.userID = try fieldContainer.decode(StringValue.self, forKey: .userID)
         self.message = try fieldContainer.decode(StringValue.self, forKey: .message)
+        self.chatRoomID = try fieldContainer.decode(StringValue.self, forKey: .chatRoomID)
+        self.date = try fieldContainer.decode(IntegerValue.self, forKey: .date)
+        self.readUserIDs = try fieldContainer.decode(ArrayValue<StringValue>.self, forKey: .readUserIDs)
     }
     
     func toDomain() -> Chat {
         return Chat(
             id: id.value,
             userID: userID.value,
-            message: message.value
+            message: message.value,
+            chatRoomID: chatRoomID.value,
+            date: Int(date.value) ?? 0,
+            readUserIDs: readUserIDs.arrayValue.map { $0.value }.flatMap { $0.map { $0.value } }
         )
     }
 }

--- a/Mogakco/Sources/Data/DataMapping/ChatRoomResponseDTO.swift
+++ b/Mogakco/Sources/Data/DataMapping/ChatRoomResponseDTO.swift
@@ -10,7 +10,7 @@ import Foundation
 
 struct ChatRoomResponseDTO: Codable {
     private let id: StringValue
-    private let studyID: StringValue
+    private let studyID: StringValue?
     private let userIDs: ArrayValue<StringValue>
     
     private enum RootKey: String, CodingKey {
@@ -25,15 +25,17 @@ struct ChatRoomResponseDTO: Codable {
         let container = try decoder.container(keyedBy: RootKey.self)
         let fieldContainer = try container.nestedContainer(keyedBy: FieldKeys.self, forKey: .fields)
         self.id = try fieldContainer.decode(StringValue.self, forKey: .id)
-        self.studyID = try fieldContainer.decode(StringValue.self, forKey: .studyID)
+        self.studyID = try fieldContainer.decodeIfPresent(StringValue.self, forKey: .studyID)
         self.userIDs = try fieldContainer.decode(ArrayValue<StringValue>.self, forKey: .userIDs)
     }
     
     func toDomain() -> ChatRoom {
         return ChatRoom(
             id: id.value,
-            studyID: studyID.value,
-            userIDs: userIDs.arrayValue.map { $0.value }.flatMap { $0.map { $0.value } }
+            studyID: studyID?.value,
+            userIDs: userIDs.arrayValue.map { $0.value }.flatMap { $0.map { $0.value } },
+            latestChat: nil,
+            unreadChatCount: nil
         )
     }
 }

--- a/Mogakco/Sources/Data/DataSources/Protocol/ChatRoomDataSourceProtocol.swift
+++ b/Mogakco/Sources/Data/DataSources/Protocol/ChatRoomDataSourceProtocol.swift
@@ -10,4 +10,5 @@ import RxSwift
 
 protocol ChatRoomDataSourceProtocol {
     func list() -> Observable<Documents<[ChatRoomResponseDTO]>>
+    func chats(id: String) -> Observable<Documents<[ChatResponseDTO]>>
 }

--- a/Mogakco/Sources/Data/DataSources/Remote/ChatRoomDataSource.swift
+++ b/Mogakco/Sources/Data/DataSources/Remote/ChatRoomDataSource.swift
@@ -19,10 +19,14 @@ struct ChatRoomDataSource: ChatRoomDataSourceProtocol {
     func list() -> Observable<Documents<[ChatRoomResponseDTO]>> {
         return provider.request(ChatRoomTarget.list)
     }
+    
+    func chats(id: String) -> Observable<Documents<[ChatResponseDTO]>> {
+        return provider.request(ChatRoomTarget.chats(id))
+    }
 }
 
 enum ChatRoomTarget {
-    case list
+    case list, chats(String)
 }
 
 extension ChatRoomTarget: TargetType {
@@ -34,22 +38,23 @@ extension ChatRoomTarget: TargetType {
         switch self {
         case .list:
             return .get
+        case .chats:
+            return .get
         }
     }
     
     var header: HTTPHeaders {
-        switch self {
-        case .list:
-            return [
-                "Content-Type": "application/json"
-            ]
-        }
+        return [
+            "Content-Type": "application/json"
+        ]
     }
     
     var path: String {
         switch self {
         case .list:
             return ""
+        case let .chats(id):
+            return "/\(id)/chats"
         }
     }
     
@@ -57,13 +62,12 @@ extension ChatRoomTarget: TargetType {
         switch self {
         case .list:
             return nil
+        case .chats:
+            return nil
         }
     }
     
     var encoding: ParameterEncoding {
-        switch self {
-        case .list:
-            return JSONEncoding.default
-        }
+        return JSONEncoding.default
     }
 }

--- a/Mogakco/Sources/Data/Repositories/ChatRoomRepository.swift
+++ b/Mogakco/Sources/Data/Repositories/ChatRoomRepository.swift
@@ -35,10 +35,11 @@ struct ChatRoomRepository: ChatRoomRepositoryProtocol {
                 chatRooms.forEach { chatRoom in
                     chatRoomDataSource.chats(id: chatRoom.id)
                         .map { $0.documents.map { $0.toDomain() } }
-                        .map { $0.sorted { $0.date < $1.date } } // TODO: 정렬 API 쿼리로 이동
+                        .map { $0.sorted { $0.date < $1.date } } // TODO: 메세지 정렬 API 쿼리로 이동
                         .map { ($0.first, unreadChatCount(id: id, chats: $0)) }
                         .map { ChatRoom(chatRoom: chatRoom, latestChat: $0.0, unreadChatCount: $0.1) }
                         .withLatestFrom(latestChatChatRoomsSb) { $1 + [$0] }
+                        .map { $0.sorted { $0.latestChat?.date ?? 0 < $1.latestChat?.date ?? 0 } }
                         .subscribe(onNext: {
                             latestChatChatRoomsSb.onNext($0)
                         })

--- a/Mogakco/Sources/Domain/Entities/Chat.swift
+++ b/Mogakco/Sources/Domain/Entities/Chat.swift
@@ -12,4 +12,7 @@ struct Chat {
     let id: String
     let userID: String
     let message: String
+    let chatRoomID: String
+    let date: Int
+    let readUserIDs: [String]
 }

--- a/Mogakco/Sources/Domain/Entities/ChatRoom.swift
+++ b/Mogakco/Sources/Domain/Entities/ChatRoom.swift
@@ -10,6 +10,18 @@ import Foundation
 
 struct ChatRoom {
     let id: String
-    let studyID: String
+    let studyID: String?
     let userIDs: [String]
+    let latestChat: Chat?
+    let unreadChatCount: Int?
+}
+
+extension ChatRoom {
+    init(chatRoom: ChatRoom, latestChat: Chat?, unreadChatCount: Int) {
+        self.id = chatRoom.id
+        self.studyID = chatRoom.studyID
+        self.userIDs = chatRoom.userIDs
+        self.latestChat = latestChat
+        self.unreadChatCount = unreadChatCount
+    }
 }

--- a/Mogakco/Sources/Domain/Repositories/ChatRoomRepositoryProtocol.swift
+++ b/Mogakco/Sources/Domain/Repositories/ChatRoomRepositoryProtocol.swift
@@ -9,5 +9,5 @@
 import RxSwift
 
 protocol ChatRoomRepositoryProtocol {
-    func list(ids: [String]) -> Observable<[ChatRoom]>
+    func list(id: String, ids: [String]) -> Observable<[ChatRoom]>
 }

--- a/Mogakco/Sources/Domain/UseCases/ChatRoomListUseCase.swift
+++ b/Mogakco/Sources/Domain/UseCases/ChatRoomListUseCase.swift
@@ -32,10 +32,7 @@ struct ChatRoomListUseCase: ChatRoomListUseCaseProtocol {
         return userRepository
             .load()
             .flatMap { user in
-                guard let id = user.id else {
-                    return Observable<[ChatRoom]>.error(ChatRoomListUseCaseError.nonUserID)
-                }
-                return chatRoomRepository.list(id: id, ids: user.chatRoomIDs)
+                return chatRoomRepository.list(id: user.id, ids: user.chatRoomIDs)
             }
     }
 }

--- a/Mogakco/Sources/Presentation/Chat/View/ChatRoomTableViewCell.swift
+++ b/Mogakco/Sources/Presentation/Chat/View/ChatRoomTableViewCell.swift
@@ -60,6 +60,14 @@ final class ChatRoomTableViewCell: UITableViewCell, Identifiable {
     
     func configure(chatRoom: ChatRoom) {
         chatRoomTitleLabel.text = chatRoom.userIDs.joined()
+        latestMessageLabel.text = chatRoom.latestChat?.message ?? ""
+        if let date = chatRoom.latestChat?.date {
+            latestMessageDateLabel.text = String(date)
+        }
+        if let unreadChatCount = chatRoom.unreadChatCount {
+            unreadMessageCountLabel.isHidden = unreadChatCount == 0
+            unreadMessageCountLabel.text = String(unreadChatCount)
+        }
     }
     
     private func layout() {

--- a/Mogakco/Sources/Presentation/Chat/ViewController/ChatListViewController.swift
+++ b/Mogakco/Sources/Presentation/Chat/ViewController/ChatListViewController.swift
@@ -50,6 +50,16 @@ final class ChatListViewController: UIViewController {
         layout()
     }
     
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        navigationController?.isNavigationBarHidden = true
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        navigationController?.isNavigationBarHidden = false
+    }
+    
     func bind() {
         let input = ChatListViewModel.Input(
             selectedChatRoom: chatRoomTableView.rx.itemSelected.map { _ in }.asObservable()

--- a/Mogakco/Sources/Presentation/Hashtag/ViewController/HashtagSelectViewController.swift
+++ b/Mogakco/Sources/Presentation/Hashtag/ViewController/HashtagSelectViewController.swift
@@ -71,6 +71,16 @@ class HashtagSelectViewController: ViewController {
         configDelegate()
     }
     
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        navigationController?.isNavigationBarHidden = false
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        navigationController?.isNavigationBarHidden = true
+    }
+    
     private func configDelegate() {
         hashtagListCollectionView.delegate = self
         hashtagListCollectionView.dataSource = self

--- a/Mogakco/Sources/Presentation/Profile/ViewController/ProfileViewController.swift
+++ b/Mogakco/Sources/Presentation/Profile/ViewController/ProfileViewController.swift
@@ -87,6 +87,16 @@ final class ProfileViewController: ViewController {
         super.init(nibName: nil, bundle: nil)
     }
     
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        navigationController?.isNavigationBarHidden = true
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        navigationController?.isNavigationBarHidden = false
+    }
+    
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }

--- a/Mogakco/Sources/Presentation/Study/ViewController/StudyDetailViewController.swift
+++ b/Mogakco/Sources/Presentation/Study/ViewController/StudyDetailViewController.swift
@@ -121,6 +121,16 @@ final class StudyDetailViewController: ViewController {
         configDelegate()
     }
     
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        navigationController?.isNavigationBarHidden = false
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        navigationController?.isNavigationBarHidden = true
+    }
+    
     private func configDelegate() {
         languageCollectionView.delegate = self
         languageCollectionView.dataSource = self

--- a/Mogakco/Sources/Presentation/Study/ViewController/StudyListViewController.swift
+++ b/Mogakco/Sources/Presentation/Study/ViewController/StudyListViewController.swift
@@ -46,6 +46,16 @@ final class StudyListViewController: ViewController {
         super.viewDidLoad()
     }
     
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        navigationController?.isNavigationBarHidden = true
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        navigationController?.isNavigationBarHidden = false
+    }
+    
     override func bind() {
         
         let input = StudyListViewModel.Input(


### PR DESCRIPTION
### PR Type

- [x]  기능 추가 🔨
- [ ]  버그 수정 🐞
- [ ]  리팩토링 🚧
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [ ]  테스트 🔍
 

### Related Issue(작업 내용)

- resolves #195 
  - 최신 메세지 표시 기능 구현
- resolves #200 
  - 읽지 않은 메세지 수 표시 구현  
- close #214 
  - REST로 진행해도 될 것 같아 close 합니다

### 참고 사항
먼저 Firestore로 구현해봤는데 마찬가지로 서버에 데이터 호출 횟수가 동일하여 REST로 진행하였습니다
ChatListRepository에서 최신 메세지, 읽지 않은 메세지 수를 함께 리턴합니다

### Screenshots(Optional)
<img src="https://user-images.githubusercontent.com/73675540/203723560-6b0548d3-5777-45e4-a5ed-a7cd71dce636.png" width="50%">
