### PR TITLE
카테고리 2개 선택 이슈 해결

### DIFF
--- a/Mogakco/Sources/Presentation/Hashtag/ViewController/HashtagSelectViewController.swift
+++ b/Mogakco/Sources/Presentation/Hashtag/ViewController/HashtagSelectViewController.swift
@@ -188,8 +188,8 @@ extension HashtagSelectViewController: UICollectionViewDataSource {
         guard let selectedCount = collectionView.indexPathsForSelectedItems?.count else {
             return false }
         switch kind {
-        case .language, .career: return selectedCount <= 4
-        case .category: return selectedCount <= 1
+        case .language, .career: return selectedCount < 5
+        case .category: return selectedCount < 1
         }
     }
 }


### PR DESCRIPTION
### PR Type

- [ ]  기능 추가 🔨
- [x]  버그 수정 🐞
- [ ]  리팩토링 🚧
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [ ]  테스트 🔍
 

### Related Issue(작업 내용)

- close #211 
    - Hashtag에서 Category 두 가지가 선택되는 문제 해결

### 참고 사항
- 카테고리가 2개까지 선택되었는데 1개만 선택되도록 수정했습니다. (사실 코드 한줄짜리 수정이네요 ㅎㅎ)
