### PR TITLE
해시태그 편집 기능 구현

### DIFF
--- a/Mogakco/Sources/Data/DataMapping/EditCareersRequestDTO.swift
+++ b/Mogakco/Sources/Data/DataMapping/EditCareersRequestDTO.swift
@@ -1,0 +1,31 @@
+//
+//  EditCareersRequestDTO.swift
+//  Mogakco
+//
+//  Created by 김범수 on 2022/11/25.
+//  Copyright © 2022 Mogakco. All rights reserved.
+//
+
+import Foundation
+
+struct EditCareersRequestDTO: Encodable {
+    private let careers: ArrayValue<StringValue>
+    
+    private enum RootKey: String, CodingKey {
+        case fields
+    }
+    
+    private enum FieldKeys: String, CodingKey {
+        case careers
+    }
+    
+    init(careers: [String]) {
+        self.careers = ArrayValue<StringValue>(values: careers.map { StringValue(value: $0) })
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: RootKey.self)
+        var fieldContainer = container.nestedContainer(keyedBy: FieldKeys.self, forKey: .fields)
+        try fieldContainer.encode(self.careers, forKey: .careers)
+    }
+}

--- a/Mogakco/Sources/Data/DataMapping/EditCategorysRequestDTO.swift
+++ b/Mogakco/Sources/Data/DataMapping/EditCategorysRequestDTO.swift
@@ -1,0 +1,31 @@
+//
+//  EditCategorysRequestDTO.swift
+//  Mogakco
+//
+//  Created by 김범수 on 2022/11/25.
+//  Copyright © 2022 Mogakco. All rights reserved.
+//
+
+import Foundation
+
+struct EditCategorysRequestDTO: Encodable {
+    private let categorys: ArrayValue<StringValue>
+    
+    private enum RootKey: String, CodingKey {
+        case fields
+    }
+    
+    private enum FieldKeys: String, CodingKey {
+        case categorys
+    }
+    
+    init(categorys: [String]) {
+        self.categorys = ArrayValue<StringValue>(values: categorys.map { StringValue(value: $0) })
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: RootKey.self)
+        var fieldContainer = container.nestedContainer(keyedBy: FieldKeys.self, forKey: .fields)
+        try fieldContainer.encode(self.categorys, forKey: .categorys)
+    }
+}

--- a/Mogakco/Sources/Data/DataMapping/EditLanguagesRequestDTO.swift
+++ b/Mogakco/Sources/Data/DataMapping/EditLanguagesRequestDTO.swift
@@ -1,0 +1,31 @@
+//
+//  EditLanguagesRequestDTO.swift
+//  Mogakco
+//
+//  Created by 김범수 on 2022/11/25.
+//  Copyright © 2022 Mogakco. All rights reserved.
+//
+
+import Foundation
+
+struct EditLanguagesRequestDTO: Encodable {
+    private let languages: ArrayValue<StringValue>
+    
+    private enum RootKey: String, CodingKey {
+        case fields
+    }
+    
+    private enum FieldKeys: String, CodingKey {
+        case languages
+    }
+    
+    init(languages: [String]) {
+        self.languages = ArrayValue<StringValue>(values: languages.map { StringValue(value: $0) })
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: RootKey.self)
+        var fieldContainer = container.nestedContainer(keyedBy: FieldKeys.self, forKey: .fields)
+        try fieldContainer.encode(self.languages, forKey: .languages)
+    }
+}

--- a/Mogakco/Sources/Data/DataSources/Protocol/RemoteUserDataSourceProtocol.swift
+++ b/Mogakco/Sources/Data/DataSources/Protocol/RemoteUserDataSourceProtocol.swift
@@ -15,5 +15,8 @@ protocol RemoteUserDataSourceProtocol {
     func user(id: String) -> Observable<UserResponseDTO>
     func create(request: UserRequestDTO) -> Observable<UserResponseDTO>
     func editProfile(id: String, request: EditProfileRequestDTO) -> Observable<UserResponseDTO>
+    func editLanguages(id: String, request: EditLanguagesRequestDTO) -> Observable<UserResponseDTO>
+    func editCareers(id: String, request: EditCareersRequestDTO) -> Observable<UserResponseDTO>
+    func editCategorys(id: String, request: EditCategorysRequestDTO) -> Observable<UserResponseDTO>
     func uploadProfileImage(id: String, imageData: Data) -> Observable<URL>
 }

--- a/Mogakco/Sources/Data/DataSources/Remote/RemoteUserDataSource.swift
+++ b/Mogakco/Sources/Data/DataSources/Remote/RemoteUserDataSource.swift
@@ -33,6 +33,18 @@ struct RemoteUserDataSource: RemoteUserDataSourceProtocol {
         return provider.request(UserTarget.editProfile(id, request))
     }
     
+    func editLanguages(id: String, request: EditLanguagesRequestDTO) -> Observable<UserResponseDTO> {
+        return provider.request(UserTarget.editLanguages(id, request))
+    }
+    
+    func editCareers(id: String, request: EditCareersRequestDTO) -> Observable<UserResponseDTO> {
+        return provider.request(UserTarget.editCareers(id, request))
+    }
+    
+    func editCategorys(id: String, request: EditCategorysRequestDTO) -> Observable<UserResponseDTO> {
+        return provider.request(UserTarget.editCategorys(id, request))
+    }
+    
     func uploadProfileImage(id: String, imageData: Data) -> Observable<URL> {
         return Observable.create { emitter in
             let ref = Storage.storage().reference().child("User").child(id).child("profileImageURL")
@@ -62,6 +74,9 @@ enum UserTarget {
     case createUser(UserRequestDTO)
     case users
     case editProfile(String, EditProfileRequestDTO)
+    case editLanguages(String, EditLanguagesRequestDTO)
+    case editCareers(String, EditCareersRequestDTO)
+    case editCategorys(String, EditCategorysRequestDTO)
 }
 
 extension UserTarget: TargetType {
@@ -71,13 +86,11 @@ extension UserTarget: TargetType {
     
     var method: HTTPMethod {
         switch self {
-        case .user:
-            return .get
-        case .users:
+        case .user, .users:
             return .get
         case .createUser:
             return .post
-        case .editProfile:
+        case .editProfile, .editLanguages, .editCareers, .editCategorys:
             return .patch
         }
     }
@@ -101,6 +114,12 @@ extension UserTarget: TargetType {
             + "/?updateMask.fieldPaths=name"
             + "&updateMask.fieldPaths=introduce"
             + "&updateMask.fieldPaths=profileImageURLString"
+        case let .editLanguages(id, _):
+            return "/\(id)" + "/?updateMask.fieldPaths=languages"
+        case let .editCareers(id, _):
+            return "/\(id)" + "/?updateMask.fieldPaths=careers"
+        case let .editCategorys(id, _):
+            return "/\(id)" + "/?updateMask.fieldPaths=categorys"
         }
     }
     
@@ -113,6 +132,12 @@ extension UserTarget: TargetType {
         case let .createUser(request):
             return .body(request)
         case let .editProfile(_, request):
+            return .body(request)
+        case let .editLanguages(_, request):
+            return .body(request)
+        case let .editCareers(_, request):
+            return .body(request)
+        case let .editCategorys(_, request):
             return .body(request)
         }
     }

--- a/Mogakco/Sources/Data/Repositories/UserRepository.swift
+++ b/Mogakco/Sources/Data/Repositories/UserRepository.swift
@@ -63,5 +63,23 @@ struct UserRepository: UserRepositoryProtocol {
             .flatMap { remoteUserDataSource.editProfile(id: id, request: $0) }
             .map { $0.toDomain() }
     }
+    
+    func editLanguages(id: String, languages: [String]) -> Observable<User> {
+        let request = EditLanguagesRequestDTO(languages: languages)
+        return remoteUserDataSource.editLanguages(id: id, request: request)
+            .map { $0.toDomain() }
+    }
+    
+    func editCareers(id: String, careers: [String]) -> Observable<User> {
+        let request = EditCareersRequestDTO(careers: careers)
+        return remoteUserDataSource.editCareers(id: id, request: request)
+            .map { $0.toDomain() }
+    }
+    
+    func editCategorys(id: String, categorys: [String]) -> Observable<User> {
+        let request = EditCategorysRequestDTO(categorys: categorys)
+        return remoteUserDataSource.editCategorys(id: id, request: request)
+            .map { $0.toDomain() }
+    }
 }
  

--- a/Mogakco/Sources/Domain/Repositories/UserRepositoryProtocol.swift
+++ b/Mogakco/Sources/Domain/Repositories/UserRepositoryProtocol.swift
@@ -18,4 +18,7 @@ protocol UserRepositoryProtocol {
     func load() -> Observable<User>
     func create(user: User, imageData: Data) -> Observable<User>
     func editProfile(id: String, name: String, introduce: String, imageData: Data) -> Observable<User>
+    func editLanguages(id: String, languages: [String]) -> Observable<User>
+    func editCareers(id: String, careers: [String]) -> Observable<User>
+    func editCategorys(id: String, categorys: [String]) -> Observable<User>
 }

--- a/Mogakco/Sources/Domain/UseCases/EditProfileUseCase.swift
+++ b/Mogakco/Sources/Domain/UseCases/EditProfileUseCase.swift
@@ -37,4 +37,28 @@ struct EditProfileUseCase: EditProfileUseCaseProtocol {
             }
             .flatMap { userRepository.save(user: $0) }
     }
+    
+    func editLanguages(languages: [String]) -> Observable<Void> {
+        return userRepository
+            .load()
+            .compactMap { $0.id }
+            .flatMap { userRepository.editLanguages(id: $0, languages: languages) }
+            .flatMap { userRepository.save(user: $0) }
+    }
+    
+    func editCareers(careers: [String]) -> Observable<Void> {
+        return userRepository
+            .load()
+            .compactMap { $0.id }
+            .flatMap { userRepository.editCareers(id: $0, careers: careers) }
+            .flatMap { userRepository.save(user: $0) }
+    }
+    
+    func editCategorys(categorys: [String]) -> Observable<Void> {
+        return userRepository
+            .load()
+            .compactMap { $0.id }
+            .flatMap { userRepository.editCategorys(id: $0, categorys: categorys) }
+            .flatMap { userRepository.save(user: $0) }
+    }
 }

--- a/Mogakco/Sources/Domain/UseCases/Protocol/EditProfileUseCaseProtocol.swift
+++ b/Mogakco/Sources/Domain/UseCases/Protocol/EditProfileUseCaseProtocol.swift
@@ -12,4 +12,7 @@ import RxSwift
 
 protocol EditProfileUseCaseProtocol {
     func editProfile(name: String, introduce: String, image: UIImage) -> Observable<Void>
+    func editLanguages(languages: [String]) -> Observable<Void>
+    func editCareers(careers: [String]) -> Observable<Void>
+    func editCategorys(categorys: [String]) -> Observable<Void>
 }


### PR DESCRIPTION
### PR Type

- [x]  기능 추가 🔨
- [ ]  버그 수정 🐞
- [ ]  리팩토링 🚧
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [ ]  테스트 🔍
 

### Related Issue(작업 내용)

- resolve #194 
    - EditUserUseCase - UserRepository - UserDataSource로 이어지는 해시태그 편집 기능을 구현하였습니다.
    - 편집 후 갱신된 유저 정보를 캐싱합니다.

### 참고 사항

해시태그 화면에서 EditUserUseCase로 편집 기능을 호출하는 로직을 이슈로 생성해 구현해주실 수 있을까요?! @juhoon-lee 

