### PR TITLE
스터디 상세화면 관련 네이밍 수정

### DIFF
--- a/Mogakco/Sources/Data/DataSources/Local/HashtagDataSource.swift
+++ b/Mogakco/Sources/Data/DataSources/Local/HashtagDataSource.swift
@@ -35,7 +35,7 @@ struct HashtagDataSource: HashtagDataSourceProtocol {
         return Category.allCases
     }
     
-    func loadTagByString(kind: KindHashtag, tagTitle: [String]) -> Observable<[Hashtag]> {
+    func loadHashtagByString(kind: KindHashtag, tagTitle: [String]) -> Observable<[Hashtag]> {
         return Observable.create { emitter in
             let tagList: [Hashtag]
             var selectedTags: [Hashtag] = []

--- a/Mogakco/Sources/Data/DataSources/Protocol/HashtagDataSourceProtocol.swift
+++ b/Mogakco/Sources/Data/DataSources/Protocol/HashtagDataSourceProtocol.swift
@@ -12,5 +12,5 @@ import RxSwift
 
 protocol HashtagDataSourceProtocol {
     func loadTagList(kind: KindHashtag) -> Observable<[Hashtag]>
-    func loadTagByString(kind: KindHashtag, tagTitle: [String]) -> Observable<[Hashtag]>
+    func loadHashtagByString(kind: KindHashtag, tagTitle: [String]) -> Observable<[Hashtag]>
 }

--- a/Mogakco/Sources/Data/DataSources/Remote/RemoteUserDataSource.swift
+++ b/Mogakco/Sources/Data/DataSources/Remote/RemoteUserDataSource.swift
@@ -26,7 +26,7 @@ struct RemoteUserDataSource: RemoteUserDataSourceProtocol {
     }
     
     func allUsers() -> Observable<Documents<[UserResponseDTO]>> {
-        return provider.request(UserTarget.users)
+        return provider.request(UserTarget.allUsers)
     }
     
     func editProfile(id: String, request: EditProfileRequestDTO) -> Observable<UserResponseDTO> {
@@ -72,7 +72,7 @@ struct RemoteUserDataSource: RemoteUserDataSourceProtocol {
 enum UserTarget {
     case user(String)
     case createUser(UserRequestDTO)
-    case users
+    case allUsers
     case editProfile(String, EditProfileRequestDTO)
     case editLanguages(String, EditLanguagesRequestDTO)
     case editCareers(String, EditCareersRequestDTO)
@@ -86,7 +86,7 @@ extension UserTarget: TargetType {
     
     var method: HTTPMethod {
         switch self {
-        case .user, .users:
+        case .user, .allUsers:
             return .get
         case .createUser:
             return .post
@@ -103,7 +103,7 @@ extension UserTarget: TargetType {
     
     var path: String {
         switch self {
-        case .users:
+        case .allUsers:
             return ""
         case let .user(id):
             return "/\(id)"
@@ -127,7 +127,7 @@ extension UserTarget: TargetType {
         switch self {
         case .user:
             return nil
-        case .users:
+        case .allUsers:
             return nil
         case let .createUser(request):
             return .body(request)

--- a/Mogakco/Sources/Data/Repositories/HashtagRepository.swift
+++ b/Mogakco/Sources/Data/Repositories/HashtagRepository.swift
@@ -22,7 +22,7 @@ struct HashtagRepository: HashtagRepositoryProtocol {
         return localHashtagDataSource.loadTagList(kind: kind)
     }
     
-    func loadTagByString(kind: KindHashtag, tagTitle: [String]) -> Observable<[Hashtag]> {
-        return localHashtagDataSource.loadTagByString(kind: kind, tagTitle: tagTitle)
+    func loadHashtagByString(kind: KindHashtag, tagTitle: [String]) -> Observable<[Hashtag]> {
+        return localHashtagDataSource.loadHashtagByString(kind: kind, tagTitle: tagTitle)
     }
 }

--- a/Mogakco/Sources/Domain/Repositories/HashtagRepositoryProtocol.swift
+++ b/Mogakco/Sources/Domain/Repositories/HashtagRepositoryProtocol.swift
@@ -12,5 +12,5 @@ import RxSwift
 
 protocol HashtagRepositoryProtocol {
     func loadTagList(kind: KindHashtag) -> Observable<[Hashtag]>
-    func loadTagByString(kind: KindHashtag, tagTitle: [String]) -> Observable<[Hashtag]>
+    func loadHashtagByString(kind: KindHashtag, tagTitle: [String]) -> Observable<[Hashtag]>
 }

--- a/Mogakco/Sources/Domain/UseCases/HashtagUseCase.swift
+++ b/Mogakco/Sources/Domain/UseCases/HashtagUseCase.swift
@@ -22,7 +22,7 @@ struct HashtagUsecase: HashtagUseCaseProtocol {
         return hashtagRepository.loadTagList(kind: kind)
     }
     
-    func loadTagByString(kind: KindHashtag, tagTitle: [String]) -> Observable<[Hashtag]> {
-        return hashtagRepository.loadTagByString(kind: kind, tagTitle: tagTitle)
+    func loadHashtagByString(kind: KindHashtag, tagTitle: [String]) -> Observable<[Hashtag]> {
+        return hashtagRepository.loadHashtagByString(kind: kind, tagTitle: tagTitle)
     }
 }

--- a/Mogakco/Sources/Domain/UseCases/Protocol/HashtagUseCaseProtocol.swift
+++ b/Mogakco/Sources/Domain/UseCases/Protocol/HashtagUseCaseProtocol.swift
@@ -12,5 +12,5 @@ import RxSwift
 
 protocol HashtagUseCaseProtocol {
     func loadTagList(kind: KindHashtag) -> Observable<[Hashtag]>
-    func loadTagByString(kind: KindHashtag, tagTitle: [String]) -> Observable<[Hashtag]>
+    func loadHashtagByString(kind: KindHashtag, tagTitle: [String]) -> Observable<[Hashtag]>
 }

--- a/Mogakco/Sources/Presentation/Study/ViewController/StudyDetailViewController.swift
+++ b/Mogakco/Sources/Presentation/Study/ViewController/StudyDetailViewController.swift
@@ -154,7 +154,7 @@ final class StudyDetailViewController: ViewController {
         output.studyDetail
             .subscribe(onNext: { [weak self] in
                 self?.studyTitleLabel.text = $0.title
-                self?.dateView.textLabel.text = "\($0.date.toCompactDateString())"
+                self?.dateView.textLabel.text = $0.date.toCompactDateString()
                 self?.participantsView.textLabel.text = "\($0.userIDs.count)/\($0.maxUserCount)"
                 self?.locationView.textLabel.text = $0.place
                 self?.studyInfoDescription.text = $0.content

--- a/Mogakco/Sources/Presentation/Study/ViewController/StudyDetailViewController.swift
+++ b/Mogakco/Sources/Presentation/Study/ViewController/StudyDetailViewController.swift
@@ -154,7 +154,7 @@ final class StudyDetailViewController: ViewController {
         output.studyDetail
             .subscribe(onNext: { [weak self] in
                 self?.studyTitleLabel.text = $0.title
-                self?.dateView.textLabel.text = "\($0.date)"
+                self?.dateView.textLabel.text = "\($0.date.toDateString())"
                 self?.participantsView.textLabel.text = "\($0.userIDs.count)/\($0.maxUserCount)"
                 self?.locationView.textLabel.text = $0.place
                 self?.studyInfoDescription.text = $0.content

--- a/Mogakco/Sources/Presentation/Study/ViewController/StudyDetailViewController.swift
+++ b/Mogakco/Sources/Presentation/Study/ViewController/StudyDetailViewController.swift
@@ -154,7 +154,7 @@ final class StudyDetailViewController: ViewController {
         output.studyDetail
             .subscribe(onNext: { [weak self] in
                 self?.studyTitleLabel.text = $0.title
-                self?.dateView.textLabel.text = "\($0.date.toDateString())"
+                self?.dateView.textLabel.text = "\($0.date.toCompactDateString())"
                 self?.participantsView.textLabel.text = "\($0.userIDs.count)/\($0.maxUserCount)"
                 self?.locationView.textLabel.text = $0.place
                 self?.studyInfoDescription.text = $0.content

--- a/Mogakco/Sources/Presentation/Study/ViewController/StudyDetailViewController.swift
+++ b/Mogakco/Sources/Presentation/Study/ViewController/StudyDetailViewController.swift
@@ -316,7 +316,7 @@ extension StudyDetailViewController: UICollectionViewDataSource {
             
             cell.prepareForReuse()
             
-            if let cellUserInfo = viewModel.participantCellInfp(index: indexPath.row) {
+            if let cellUserInfo = viewModel.participantCellInfo(index: indexPath.row) {
                 cell.setInfo(imageURLString: "프로필사진", name: cellUserInfo.name, description: cellUserInfo.introduce)
             } else {
                 cell.setInfo(imageURLString: "person", name: "김신오이", description: "iOS 개발자")

--- a/Mogakco/Sources/Presentation/Study/ViewModel/StudyDetailViewModel.swift
+++ b/Mogakco/Sources/Presentation/Study/ViewModel/StudyDetailViewModel.swift
@@ -69,7 +69,7 @@ final class StudyDetailViewModel: ViewModel {
         studyDetailLoad
             .withUnretained(self)
             .flatMap {
-                return $0.0.hashtagUseCase.loadTagByString(kind: .language, tagTitle: $0.1.languages)
+                return $0.0.hashtagUseCase.loadHashtagByString(kind: .language, tagTitle: $0.1.languages)
             }
             .subscribe(onNext: { [weak self] in
                 self?.languages.onNext($0)

--- a/Mogakco/Sources/Presentation/Study/ViewModel/StudyDetailViewModel.swift
+++ b/Mogakco/Sources/Presentation/Study/ViewModel/StudyDetailViewModel.swift
@@ -119,7 +119,7 @@ final class StudyDetailViewModel: ViewModel {
         return try? languages.value()[index]
     }
     
-    func  participantCellInfp(index: Int) -> User? {
+    func  participantCellInfo(index: Int) -> User? {
         return try? participants.value()[index]
     }
 }


### PR DESCRIPTION
### PR Type

- [ ]  기능 추가 🔨
- [ ]  버그 수정 🐞
- [x]  리팩토링 🚧
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [ ]  테스트 🔍
 

### Related Issue(작업 내용)

- close #230 
    - loadTagByString -> loadHashtagByString
    -  전체 유저 받는 API 네이밍 users -> allUsers
    - participantCellInfo() 오타 수정 (기존 participantCellInfp)
    - date 표시 -> $0.date.toCompactDateString()로 변경

### 참고 사항

- 네이밍, 오타, 스터디 디테일의 date 화면 출력 String을 수정했습니다.
