### PR TITLE
User의 chatRoomIDs, studyIDs 필드 업데이트를 위한 API 구현

### DIFF
--- a/Mogakco/Sources/Data/DataMapping/UpdateStudyIDRequestDTO.swift
+++ b/Mogakco/Sources/Data/DataMapping/UpdateStudyIDRequestDTO.swift
@@ -1,0 +1,34 @@
+//
+//  UpdateStudyIDRequestDTO.swift
+//  Mogakco
+//
+//  Created by 신소민 on 2022/11/26.
+//  Copyright © 2022 Mogakco. All rights reserved.
+//
+
+import Foundation
+
+struct UpdateStudyIDRequestDTO: Encodable {
+    private let chatRoomIDs: ArrayValue<StringValue>
+    private let studyIDs: ArrayValue<StringValue>
+    
+    private enum RootKey: String, CodingKey {
+        case fields
+    }
+    
+    private enum FieldKeys: String, CodingKey {
+        case chatRoomIDs, studyIDs
+    }
+    
+    init(chatRoomIDs: [String], studyIDs: [String]) {
+        self.chatRoomIDs = ArrayValue(values: chatRoomIDs.map { StringValue(value: $0) })
+        self.studyIDs = ArrayValue(values: studyIDs.map { StringValue(value: $0) })
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: RootKey.self)
+        var fieldContainer = container.nestedContainer(keyedBy: FieldKeys.self, forKey: .fields)
+        try fieldContainer.encode(self.chatRoomIDs, forKey: .chatRoomIDs)
+        try fieldContainer.encode(self.studyIDs, forKey: .studyIDs)
+    }
+}

--- a/Mogakco/Sources/Data/DataMapping/UpdateStudyIDsRequestDTO.swift
+++ b/Mogakco/Sources/Data/DataMapping/UpdateStudyIDsRequestDTO.swift
@@ -1,5 +1,5 @@
 //
-//  UpdateStudyIDRequestDTO.swift
+//  UpdateStudyIDsRequestDTO.swift
 //  Mogakco
 //
 //  Created by 신소민 on 2022/11/26.
@@ -8,7 +8,7 @@
 
 import Foundation
 
-struct UpdateStudyIDRequestDTO: Encodable {
+struct UpdateStudyIDsRequestDTO: Encodable {
     private let chatRoomIDs: ArrayValue<StringValue>
     private let studyIDs: ArrayValue<StringValue>
     

--- a/Mogakco/Sources/Data/DataSources/Protocol/RemoteUserDataSourceProtocol.swift
+++ b/Mogakco/Sources/Data/DataSources/Protocol/RemoteUserDataSourceProtocol.swift
@@ -19,4 +19,5 @@ protocol RemoteUserDataSourceProtocol {
     func editCareers(id: String, request: EditCareersRequestDTO) -> Observable<UserResponseDTO>
     func editCategorys(id: String, request: EditCategorysRequestDTO) -> Observable<UserResponseDTO>
     func uploadProfileImage(id: String, imageData: Data) -> Observable<URL>
+    func updateIDs(id: String, request: UpdateStudyIDRequestDTO) -> Observable<UserResponseDTO>
 }

--- a/Mogakco/Sources/Data/DataSources/Protocol/RemoteUserDataSourceProtocol.swift
+++ b/Mogakco/Sources/Data/DataSources/Protocol/RemoteUserDataSourceProtocol.swift
@@ -19,5 +19,5 @@ protocol RemoteUserDataSourceProtocol {
     func editCareers(id: String, request: EditCareersRequestDTO) -> Observable<UserResponseDTO>
     func editCategorys(id: String, request: EditCategorysRequestDTO) -> Observable<UserResponseDTO>
     func uploadProfileImage(id: String, imageData: Data) -> Observable<URL>
-    func updateIDs(id: String, request: UpdateStudyIDRequestDTO) -> Observable<UserResponseDTO>
+    func updateIDs(id: String, request: UpdateStudyIDsRequestDTO) -> Observable<UserResponseDTO>
 }

--- a/Mogakco/Sources/Data/DataSources/Remote/RemoteUserDataSource.swift
+++ b/Mogakco/Sources/Data/DataSources/Remote/RemoteUserDataSource.swift
@@ -68,7 +68,7 @@ struct RemoteUserDataSource: RemoteUserDataSourceProtocol {
         }
     }
     
-    func updateIDs(id: String, request: UpdateStudyIDRequestDTO) -> Observable<UserResponseDTO> {
+    func updateIDs(id: String, request: UpdateStudyIDsRequestDTO) -> Observable<UserResponseDTO> {
         return provider.request(UserTarget.updateIDs(id, request))
     }
 }

--- a/Mogakco/Sources/Data/DataSources/Remote/RemoteUserDataSource.swift
+++ b/Mogakco/Sources/Data/DataSources/Remote/RemoteUserDataSource.swift
@@ -67,6 +67,10 @@ struct RemoteUserDataSource: RemoteUserDataSourceProtocol {
             return Disposables.create()
         }
     }
+    
+    func updateIDs(id: String, request: UpdateStudyIDRequestDTO) -> Observable<UserResponseDTO> {
+        return provider.request(UserTarget.updateIDs(id, request))
+    }
 }
 
 enum UserTarget {
@@ -77,6 +81,7 @@ enum UserTarget {
     case editLanguages(String, EditLanguagesRequestDTO)
     case editCareers(String, EditCareersRequestDTO)
     case editCategorys(String, EditCategorysRequestDTO)
+    case updateIDs(String, UpdateStudyIDRequestDTO)
 }
 
 extension UserTarget: TargetType {
@@ -91,6 +96,8 @@ extension UserTarget: TargetType {
         case .createUser:
             return .post
         case .editProfile, .editLanguages, .editCareers, .editCategorys:
+            return .patch
+        case .updateIDs:
             return .patch
         }
     }
@@ -120,6 +127,10 @@ extension UserTarget: TargetType {
             return "/\(id)" + "/?updateMask.fieldPaths=careers"
         case let .editCategorys(id, _):
             return "/\(id)" + "/?updateMask.fieldPaths=categorys"
+        case let .updateIDs(id, _):
+            return "/\(id)"
+            + "/?updateMask.fieldPaths=chatRoomIDs"
+            + "&updateMask.fieldPaths=studyIDs"
         }
     }
     
@@ -138,6 +149,8 @@ extension UserTarget: TargetType {
         case let .editCareers(_, request):
             return .body(request)
         case let .editCategorys(_, request):
+            return .body(request)
+        case let .updateIDs(_, request):
             return .body(request)
         }
     }

--- a/Mogakco/Sources/Data/Repositories/UserRepository.swift
+++ b/Mogakco/Sources/Data/Repositories/UserRepository.swift
@@ -56,10 +56,21 @@ struct UserRepository: UserRepositoryProtocol {
             .map { $0.toDomain() }
     }
     
-    func editProfile(id: String, name: String, introduce: String, imageData: Data) -> Observable<User> {
+    func editProfile(
+        id: String,
+        name: String,
+        introduce: String,
+        imageData: Data
+    ) -> Observable<User> {
         return remoteUserDataSource.uploadProfileImage(id: id, imageData: imageData)
             .map { $0.absoluteString }
-            .map { EditProfileRequestDTO(name: name, introduce: introduce, profileImageURLString: $0) }
+            .map {
+                EditProfileRequestDTO(
+                    name: name,
+                    introduce: introduce,
+                    profileImageURLString: $0
+                )
+            }
             .flatMap { remoteUserDataSource.editProfile(id: id, request: $0) }
             .map { $0.toDomain() }
     }
@@ -79,6 +90,16 @@ struct UserRepository: UserRepositoryProtocol {
     func editCategorys(id: String, categorys: [String]) -> Observable<User> {
         let request = EditCategorysRequestDTO(categorys: categorys)
         return remoteUserDataSource.editCategorys(id: id, request: request)
+            .map { $0.toDomain() }
+    }
+    
+    func updateIDs(
+        id: String,
+        chatRoomIDs: [String],
+        studyIDs: [String]
+    ) -> Observable<User> {
+        let request = UpdateStudyIDRequestDTO(chatRoomIDs: chatRoomIDs, studyIDs: studyIDs)
+        return remoteUserDataSource.updateIDs(id: id, request: request)
             .map { $0.toDomain() }
     }
 }

--- a/Mogakco/Sources/Data/Repositories/UserRepository.swift
+++ b/Mogakco/Sources/Data/Repositories/UserRepository.swift
@@ -98,7 +98,7 @@ struct UserRepository: UserRepositoryProtocol {
         chatRoomIDs: [String],
         studyIDs: [String]
     ) -> Observable<User> {
-        let request = UpdateStudyIDRequestDTO(chatRoomIDs: chatRoomIDs, studyIDs: studyIDs)
+        let request = UpdateStudyIDsRequestDTO(chatRoomIDs: chatRoomIDs, studyIDs: studyIDs)
         return remoteUserDataSource.updateIDs(id: id, request: request)
             .map { $0.toDomain() }
     }

--- a/Mogakco/Sources/Domain/Repositories/UserRepositoryProtocol.swift
+++ b/Mogakco/Sources/Domain/Repositories/UserRepositoryProtocol.swift
@@ -21,4 +21,5 @@ protocol UserRepositoryProtocol {
     func editLanguages(id: String, languages: [String]) -> Observable<User>
     func editCareers(id: String, careers: [String]) -> Observable<User>
     func editCategorys(id: String, categorys: [String]) -> Observable<User>
+    func updateIDs(id: String, chatRoomIDs: [String], studyIDs: [String]) -> Observable<User>
 }

--- a/Mogakco/Sources/Domain/UseCases/CreateStudyUseCase.swift
+++ b/Mogakco/Sources/Domain/UseCases/CreateStudyUseCase.swift
@@ -22,11 +22,21 @@ struct CreateStudyUseCase: CreateStudyUseCaseProtocol {
         self.userRepository = userRepository
     }
     
-    func create(study: Study) -> Observable<Study> {
+    func create(study: Study) -> Observable<Void> {
         var study = study
         return userRepository.load()
             .compactMap { $0.id }
             .map { study.userIDs.append($0) }
-            .flatMap { studyRepository.create(study: study) }
+            .flatMap { studyRepository.create(study: study) } // 1. 스터디 생성
+//            .flatMap { } // 2. 채팅방 생성
+            .flatMap { _ in userRepository.load() } // 3. 유저 업데이트
+            .flatMap {
+                userRepository.updateIDs(
+                    id: $0.id,
+                    chatRoomIDs: $0.chatRoomIDs + [study.id],
+                    studyIDs: $0.chatRoomIDs + [study.id]
+                )
+            }
+            .map { _ in return () }
     }
 }

--- a/Mogakco/Sources/Domain/UseCases/CreateStudyUseCase.swift
+++ b/Mogakco/Sources/Domain/UseCases/CreateStudyUseCase.swift
@@ -25,7 +25,7 @@ struct CreateStudyUseCase: CreateStudyUseCaseProtocol {
     func create(study: Study) -> Observable<Void> {
         var study = study
         return userRepository.load()
-            .compactMap { $0.id }
+            .map { $0.id }
             .map { study.userIDs.append($0) }
             .flatMap { studyRepository.create(study: study) } // 1. 스터디 생성
 //            .flatMap { } // 2. 채팅방 생성

--- a/Mogakco/Sources/Domain/UseCases/CreateStudyUseCase.swift
+++ b/Mogakco/Sources/Domain/UseCases/CreateStudyUseCase.swift
@@ -34,7 +34,7 @@ struct CreateStudyUseCase: CreateStudyUseCaseProtocol {
                 userRepository.updateIDs(
                     id: $0.id,
                     chatRoomIDs: $0.chatRoomIDs + [study.id],
-                    studyIDs: $0.chatRoomIDs + [study.id]
+                    studyIDs: $0.studyIDs + [study.id]
                 )
             }
             .map { _ in return () }

--- a/Mogakco/Sources/Domain/UseCases/Protocol/CreateStudyUseCaseProtocol.swift
+++ b/Mogakco/Sources/Domain/UseCases/Protocol/CreateStudyUseCaseProtocol.swift
@@ -9,5 +9,5 @@
 import RxSwift
 
 protocol CreateStudyUseCaseProtocol {
-    func create(study: Study) -> Observable<Study>
+    func create(study: Study) -> Observable<Void>
 }


### PR DESCRIPTION
### PR Type

- [X]  기능 추가 🔨
- [ ]  버그 수정 🐞
- [ ]  리팩토링 🚧
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [ ]  테스트 🔍
 

### Related Issue(작업 내용)

> 이슈 번호와 구현 내용 및 작업 했던 내역을 입력해주세요!
> 
- close #216
    - User의 chatRoomIDs, studyIDs 필드를 업데이트하기 위한 API를 구현했습니다.
    - 기존의 배열에 새로운 값을 추가하는게 어려워서 서버에서 User의 정보를 가져온뒤
       새로운 id를 추가해서 데이터를 덮어씌우는 방식으로 사용해야 합니다.

```swift
.flatMap { _ in userRepository.load() } // 3. 유저 업데이트
.flatMap {
    userRepository.updateIDs(
        id: $0.id,
        chatRoomIDs: $0.chatRoomIDs + [study.id],
        studyIDs: $0.studyIDs + [study.id]
    )
}
```
