### PR TITLE
ChatRoom, Study의 userIDs 업데이트 API 구현

### DIFF
--- a/Mogakco/Sources/Data/DataMapping/UpdateUserIDRequestDTO.swift
+++ b/Mogakco/Sources/Data/DataMapping/UpdateUserIDRequestDTO.swift
@@ -1,0 +1,31 @@
+//
+//  UpdateUserIDRequestDTO.swift.swift
+//  Mogakco
+//
+//  Created by 신소민 on 2022/11/26.
+//  Copyright © 2022 Mogakco. All rights reserved.
+//
+
+import Foundation
+
+struct UpdateUserIDRequestDTO: Encodable {
+    private let userIDs: ArrayValue<StringValue>
+    
+    private enum RootKey: String, CodingKey {
+        case fields
+    }
+    
+    private enum FieldKeys: String, CodingKey {
+        case userIDs
+    }
+    
+    init(userIDs: [String]) {
+        self.userIDs = ArrayValue(values: userIDs.map { StringValue(value: $0) })
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: RootKey.self)
+        var fieldContainer = container.nestedContainer(keyedBy: FieldKeys.self, forKey: .fields)
+        try fieldContainer.encode(self.userIDs, forKey: .userIDs)
+    }
+}

--- a/Mogakco/Sources/Data/DataMapping/UpdateUserIDsRequestDTO.swift
+++ b/Mogakco/Sources/Data/DataMapping/UpdateUserIDsRequestDTO.swift
@@ -1,5 +1,5 @@
 //
-//  UpdateUserIDRequestDTO.swift.swift
+//  UpdateUserIDsRequestDTO.swift.swift
 //  Mogakco
 //
 //  Created by 신소민 on 2022/11/26.
@@ -8,7 +8,7 @@
 
 import Foundation
 
-struct UpdateUserIDRequestDTO: Encodable {
+struct UpdateUserIDsRequestDTO: Encodable {
     private let userIDs: ArrayValue<StringValue>
     
     private enum RootKey: String, CodingKey {

--- a/Mogakco/Sources/Data/DataSources/Protocol/ChatRoomDataSourceProtocol.swift
+++ b/Mogakco/Sources/Data/DataSources/Protocol/ChatRoomDataSourceProtocol.swift
@@ -12,5 +12,5 @@ protocol ChatRoomDataSourceProtocol {
     func list() -> Observable<Documents<[ChatRoomResponseDTO]>>
     func chats(id: String) -> Observable<Documents<[ChatResponseDTO]>>
     func create(request: CreateChatRoomRequestDTO) -> Observable<ChatRoomResponseDTO>
-    func updateIDs(id: String, request: UpdateUserIDRequestDTO) -> Observable<ChatRoomResponseDTO>
+    func updateIDs(id: String, request: UpdateUserIDsRequestDTO) -> Observable<ChatRoomResponseDTO>
 }

--- a/Mogakco/Sources/Data/DataSources/Protocol/ChatRoomDataSourceProtocol.swift
+++ b/Mogakco/Sources/Data/DataSources/Protocol/ChatRoomDataSourceProtocol.swift
@@ -12,4 +12,5 @@ protocol ChatRoomDataSourceProtocol {
     func list() -> Observable<Documents<[ChatRoomResponseDTO]>>
     func chats(id: String) -> Observable<Documents<[ChatResponseDTO]>>
     func create(request: CreateChatRoomRequestDTO) -> Observable<ChatRoomResponseDTO>
+    func updateIDs(id: String, request: UpdateUserIDRequestDTO) -> Observable<ChatRoomResponseDTO>
 }

--- a/Mogakco/Sources/Data/DataSources/Protocol/StudyDataSourceProtocol.swift
+++ b/Mogakco/Sources/Data/DataSources/Protocol/StudyDataSourceProtocol.swift
@@ -12,5 +12,5 @@ protocol StudyDataSourceProtocol {
     func list() -> Observable<Documents<[StudyResponseDTO]>>
     func detail(id: String) -> Observable<StudyResponseDTO>
     func create(study: StudyRequestDTO) -> Observable<StudyResponseDTO>
-    func updateIDs(id: String, request: UpdateUserIDRequestDTO) -> Observable<StudyResponseDTO>
+    func updateIDs(id: String, request: UpdateUserIDsRequestDTO) -> Observable<StudyResponseDTO>
 }

--- a/Mogakco/Sources/Data/DataSources/Protocol/StudyDataSourceProtocol.swift
+++ b/Mogakco/Sources/Data/DataSources/Protocol/StudyDataSourceProtocol.swift
@@ -12,4 +12,5 @@ protocol StudyDataSourceProtocol {
     func list() -> Observable<Documents<[StudyResponseDTO]>>
     func detail(id: String) -> Observable<StudyResponseDTO>
     func create(study: StudyRequestDTO) -> Observable<StudyResponseDTO>
+    func updateIDs(id: String, request: UpdateUserIDRequestDTO) -> Observable<StudyResponseDTO>
 }

--- a/Mogakco/Sources/Data/DataSources/Remote/ChatRoomDataSource.swift
+++ b/Mogakco/Sources/Data/DataSources/Remote/ChatRoomDataSource.swift
@@ -29,7 +29,7 @@ struct ChatRoomDataSource: ChatRoomDataSourceProtocol {
     }
     
     func updateIDs(id: String, request: UpdateUserIDRequestDTO) -> Observable<ChatRoomResponseDTO> {
-        return provider.request(StudyTarget.updateIDs(id, request))
+        return provider.request(ChatRoomTarget.updateIDs(id, request))
     }
 }
 

--- a/Mogakco/Sources/Data/DataSources/Remote/ChatRoomDataSource.swift
+++ b/Mogakco/Sources/Data/DataSources/Remote/ChatRoomDataSource.swift
@@ -27,10 +27,17 @@ struct ChatRoomDataSource: ChatRoomDataSourceProtocol {
     func create(request: CreateChatRoomRequestDTO) -> Observable<ChatRoomResponseDTO> {
         return provider.request(ChatRoomTarget.create(request))
     }
+    
+    func updateIDs(id: String, request: UpdateUserIDRequestDTO) -> Observable<ChatRoomResponseDTO> {
+        return provider.request(StudyTarget.updateIDs(id, request))
+    }
 }
 
 enum ChatRoomTarget {
-    case list, chats(String), create(CreateChatRoomRequestDTO)
+    case list
+    case chats(String)
+    case create(CreateChatRoomRequestDTO)
+    case updateIDs(String, UpdateUserIDRequestDTO)
 }
 
 extension ChatRoomTarget: TargetType {
@@ -44,6 +51,8 @@ extension ChatRoomTarget: TargetType {
             return .get
         case .create:
             return .post
+        case .updateIDs:
+            return .patch
         }
     }
     
@@ -61,6 +70,9 @@ extension ChatRoomTarget: TargetType {
             return "/\(id)/chats"
         case let .create(request):
             return "/?documentId=\(request.id.value)"
+        case .updateIDs(let id, _):
+            return "/\(id)"
+            + "/?updateMask.fieldPaths=userIDs"
         }
     }
     
@@ -69,6 +81,8 @@ extension ChatRoomTarget: TargetType {
         case .list, .chats:
             return nil
         case let .create(request):
+            return .body(request)
+        case .updateIDs(_, let request):
             return .body(request)
         }
     }

--- a/Mogakco/Sources/Data/DataSources/Remote/ChatRoomDataSource.swift
+++ b/Mogakco/Sources/Data/DataSources/Remote/ChatRoomDataSource.swift
@@ -28,7 +28,7 @@ struct ChatRoomDataSource: ChatRoomDataSourceProtocol {
         return provider.request(ChatRoomTarget.create(request))
     }
     
-    func updateIDs(id: String, request: UpdateUserIDRequestDTO) -> Observable<ChatRoomResponseDTO> {
+    func updateIDs(id: String, request: UpdateUserIDsRequestDTO) -> Observable<ChatRoomResponseDTO> {
         return provider.request(ChatRoomTarget.updateIDs(id, request))
     }
 }
@@ -37,7 +37,7 @@ enum ChatRoomTarget {
     case list
     case chats(String)
     case create(CreateChatRoomRequestDTO)
-    case updateIDs(String, UpdateUserIDRequestDTO)
+    case updateIDs(String, UpdateUserIDsRequestDTO)
 }
 
 extension ChatRoomTarget: TargetType {

--- a/Mogakco/Sources/Data/DataSources/Remote/RemoteUserDataSource.swift
+++ b/Mogakco/Sources/Data/DataSources/Remote/RemoteUserDataSource.swift
@@ -81,7 +81,7 @@ enum UserTarget {
     case editLanguages(String, EditLanguagesRequestDTO)
     case editCareers(String, EditCareersRequestDTO)
     case editCategorys(String, EditCategorysRequestDTO)
-    case updateIDs(String, UpdateStudyIDRequestDTO)
+    case updateIDs(String, UpdateStudyIDsRequestDTO)
 }
 
 extension UserTarget: TargetType {

--- a/Mogakco/Sources/Data/DataSources/Remote/StudyDataSource.swift
+++ b/Mogakco/Sources/Data/DataSources/Remote/StudyDataSource.swift
@@ -29,7 +29,7 @@ struct StudyDataSource: StudyDataSourceProtocol {
         return provider.request(StudyTarget.create(study))
     }
     
-    func updateIDs(id: String, request: UpdateUserIDRequestDTO) -> Observable<StudyResponseDTO> {
+    func updateIDs(id: String, request: UpdateUserIDsRequestDTO) -> Observable<StudyResponseDTO> {
         return provider.request(StudyTarget.updateIDs(id, request))
     }
 }
@@ -38,7 +38,7 @@ enum StudyTarget {
     case list
     case detail(String)
     case create(StudyRequestDTO)
-    case updateIDs(String, UpdateUserIDRequestDTO)
+    case updateIDs(String, UpdateUserIDsRequestDTO)
 }
 
 extension StudyTarget: TargetType {

--- a/Mogakco/Sources/Data/DataSources/Remote/StudyDataSource.swift
+++ b/Mogakco/Sources/Data/DataSources/Remote/StudyDataSource.swift
@@ -28,12 +28,17 @@ struct StudyDataSource: StudyDataSourceProtocol {
     func create(study: StudyRequestDTO) -> Observable<StudyResponseDTO> {
         return provider.request(StudyTarget.create(study))
     }
+    
+    func updateIDs(id: String, request: UpdateUserIDRequestDTO) -> Observable<StudyResponseDTO> {
+        return provider.request(StudyTarget.updateIDs(id, request))
+    }
 }
 
 enum StudyTarget {
     case list
     case detail(String)
     case create(StudyRequestDTO)
+    case updateIDs(String, UpdateUserIDRequestDTO)
 }
 
 extension StudyTarget: TargetType {
@@ -47,6 +52,8 @@ extension StudyTarget: TargetType {
             return .get
         case .create:
             return .post
+        case .updateIDs:
+            return .patch
         }
     }
     
@@ -60,6 +67,9 @@ extension StudyTarget: TargetType {
             return "/\(id)"
         case .create(let study):
             return "/?documentId=\(study.id.value)"
+        case .updateIDs(let id, _):
+            return "/\(id)"
+            + "/?updateMask.fieldPaths=userIDs"
         default:
             return ""
         }
@@ -71,6 +81,8 @@ extension StudyTarget: TargetType {
             return nil
         case .create(let study):
             return .body(study)
+        case .updateIDs(_, let request):
+            return .body(request)
         }
     }
 

--- a/Mogakco/Sources/Data/Repositories/ChatRoomRepository.swift
+++ b/Mogakco/Sources/Data/Repositories/ChatRoomRepository.swift
@@ -60,6 +60,12 @@ struct ChatRoomRepository: ChatRoomRepositoryProtocol {
         return latestChatChatRoomsSb.asObservable()
     }
     
+    func updateIDs(id: String, userIDs: [String]) -> Observable<ChatRoom> {
+        let updateDTO = UpdateUserIDRequestDTO(userIDs: userIDs)
+        return chatRoomDataSource.updateIDs(id: id, request: updateDTO)
+            .map { $0.toDomain() }
+    }
+    
     private func unreadChatCount(id: String, chats: [Chat]) -> Int {
         var count = 0
         for chat in chats {

--- a/Mogakco/Sources/Data/Repositories/ChatRoomRepository.swift
+++ b/Mogakco/Sources/Data/Repositories/ChatRoomRepository.swift
@@ -61,7 +61,7 @@ struct ChatRoomRepository: ChatRoomRepositoryProtocol {
     }
     
     func updateIDs(id: String, userIDs: [String]) -> Observable<ChatRoom> {
-        let updateDTO = UpdateUserIDRequestDTO(userIDs: userIDs)
+        let updateDTO = UpdateUserIDsRequestDTO(userIDs: userIDs)
         return chatRoomDataSource.updateIDs(id: id, request: updateDTO)
             .map { $0.toDomain() }
     }

--- a/Mogakco/Sources/Data/Repositories/StudyRepository.swift
+++ b/Mogakco/Sources/Data/Repositories/StudyRepository.swift
@@ -61,4 +61,10 @@ struct StudyRepository: StudyRepositoryProtocol {
         return dataSource.create(study: studyDTO)
             .map { $0.toDomain() }
     }
+    
+    func updateIDs(id: String, userIDs: [String]) -> Observable<Study> {
+        let updateDTO = UpdateUserIDRequestDTO(userIDs: userIDs)
+        return dataSource.updateIDs(id: id, request: updateDTO)
+            .map { $0.toDomain() }
+    }
 }

--- a/Mogakco/Sources/Data/Repositories/StudyRepository.swift
+++ b/Mogakco/Sources/Data/Repositories/StudyRepository.swift
@@ -63,7 +63,7 @@ struct StudyRepository: StudyRepositoryProtocol {
     }
     
     func updateIDs(id: String, userIDs: [String]) -> Observable<Study> {
-        let updateDTO = UpdateUserIDRequestDTO(userIDs: userIDs)
+        let updateDTO = UpdateUserIDsRequestDTO(userIDs: userIDs)
         return dataSource.updateIDs(id: id, request: updateDTO)
             .map { $0.toDomain() }
     }

--- a/Mogakco/Sources/Domain/Repositories/ChatRoomRepositoryProtocol.swift
+++ b/Mogakco/Sources/Domain/Repositories/ChatRoomRepositoryProtocol.swift
@@ -11,4 +11,5 @@ import RxSwift
 protocol ChatRoomRepositoryProtocol {
     func list(id: String, ids: [String]) -> Observable<[ChatRoom]>
     func create(studyID: String?, userIDs: [String]) -> Observable<ChatRoom>
+    func updateIDs(id: String, userIDs: [String]) -> Observable<ChatRoom>
 }

--- a/Mogakco/Sources/Domain/Repositories/StudyRepositoryProtocol.swift
+++ b/Mogakco/Sources/Domain/Repositories/StudyRepositoryProtocol.swift
@@ -13,4 +13,5 @@ protocol StudyRepositoryProtocol {
     func list(ids: [String]) -> Observable<[Study]>
     func detail(id: String) -> Observable<Study>
     func create(study: Study) -> Observable<Study>
+    func updateIDs(id: String, userIDs: [String]) -> Observable<Study>
 }


### PR DESCRIPTION
### PR Type

- [X]  기능 추가 🔨
- [ ]  버그 수정 🐞
- [ ]  리팩토링 🚧
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [ ]  테스트 🔍
 

### Related Issue(작업 내용)

> 이슈 번호와 구현 내용 및 작업 했던 내역을 입력해주세요!
> 
- close #242
    - ChatRoom과 Study에 있는 userIDs 필드를 업데이트하기 위한 API를 구현했습니다.

### 참고 사항

#### Study의 userIDs 업데이트

```swift
let repo1 = StudyRepository(dataSource: StudyDataSource(provider: Provider.default))
        
repo1.updateIDs(id: "AAA", userIDs: ["???"])
    .subscribe {
        print($0)
    }
    .disposed(by: disposeBag)
```

#### ChatRoom의 userIDs 업데이트

```swift
let repo2 = ChatRoomRepository(
    chatRoomDataSource: ChatRoomDataSource(provider: Provider.default),
    chatDataSource: ChatDataSource(provider: Provider.default)
)

repo2.updateIDs(id: "0FDAE493-7BA1-40C6-9306-22307D215004", userIDs: ["!???"])
    .subscribe {
        print($0)
    }
    .disposed(by: disposeBag)
```
| userIDs 업데이트 전 | userIDs 업데이트 후 |
|---|---|
|<img width="562" alt="스크린샷 2022-11-26 오전 3 04 47" src="https://user-images.githubusercontent.com/109145755/204038705-0d59d228-7c76-4fc3-b9f1-c0474ad6e5cb.png">|<img width="483" alt="스크린샷 2022-11-26 오전 3 20 46" src="https://user-images.githubusercontent.com/109145755/204038721-d4ac6bc1-e460-4a1d-9771-26fe0d906adb.png">|