### PR TITLE
채팅방 목록 호출 시 유저 정보 호출 기능 구현

### DIFF
--- a/Mogakco/Sources/Data/DataMapping/ChatRoomResponseDTO.swift
+++ b/Mogakco/Sources/Data/DataMapping/ChatRoomResponseDTO.swift
@@ -35,7 +35,8 @@ struct ChatRoomResponseDTO: Codable {
             studyID: studyID?.value,
             userIDs: userIDs.arrayValue.map { $0.value }.flatMap { $0.map { $0.value } },
             latestChat: nil,
-            unreadChatCount: nil
+            unreadChatCount: nil,
+            users: nil
         )
     }
 }

--- a/Mogakco/Sources/Domain/Entities/ChatRoom.swift
+++ b/Mogakco/Sources/Domain/Entities/ChatRoom.swift
@@ -14,6 +14,7 @@ struct ChatRoom {
     let userIDs: [String]
     let latestChat: Chat?
     let unreadChatCount: Int?
+    let users: [User]?
 }
 
 extension ChatRoom {
@@ -23,5 +24,15 @@ extension ChatRoom {
         self.userIDs = chatRoom.userIDs
         self.latestChat = latestChat
         self.unreadChatCount = unreadChatCount
+        self.users = nil
+    }
+    
+    init(chatRoom: ChatRoom, users: [User]) {
+        self.id = chatRoom.id
+        self.studyID = chatRoom.studyID
+        self.userIDs = chatRoom.userIDs
+        self.latestChat = chatRoom.latestChat
+        self.unreadChatCount = chatRoom.unreadChatCount
+        self.users = users
     }
 }

--- a/Mogakco/Sources/Domain/UseCases/ChatRoomListUseCase.swift
+++ b/Mogakco/Sources/Domain/UseCases/ChatRoomListUseCase.swift
@@ -31,8 +31,6 @@ struct ChatRoomListUseCase: ChatRoomListUseCaseProtocol {
     func chatRooms() -> Observable<[ChatRoom]> {
         return userRepository
             .load()
-            .flatMap { user in
-                return chatRoomRepository.list(id: user.id, ids: user.chatRoomIDs)
-            }
+            .flatMap { chatRoomRepository.list(id: $0.id, ids: $0.chatRoomIDs) }
     }
 }


### PR DESCRIPTION
### PR Type

- [x]  기능 추가 🔨
- [ ]  버그 수정 🐞
- [ ]  리팩토링 🚧
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [ ]  테스트 🔍
 

### Related Issue(작업 내용)
 
- resolve #250 
    - ChatRoomRepository에서 채팅방 목록 호출 시 유저 정보를 포함하여 반환합니다.
    - ChatRoom Entity 모델 내 유저 리스트를 추가하였습니다

### 참고 사항
ChatRoom Entity 모델 내 userIDs 프로퍼티를 제거하고 싶으나 제약조건이 있어 우선 중복되더라도 userIDs, users를 모두 가지고 있도록 구현되었습니다 🤣
추후 제거될 수 있는 프로퍼티이니 가급적 users 프로퍼티를 사용하시면 좋을 것 같습니다
