### PR TITLE
채팅방 목록 상세 UI 구현

### DIFF
--- a/Mogakco/Sources/Data/DataMapping/ChatRoomResponseDTO.swift
+++ b/Mogakco/Sources/Data/DataMapping/ChatRoomResponseDTO.swift
@@ -35,7 +35,8 @@ struct ChatRoomResponseDTO: Codable {
             studyID: studyID?.value,
             userIDs: userIDs.arrayValue.map { $0.value }.flatMap { $0.map { $0.value } },
             latestChat: nil,
-            unreadChatCount: nil
+            unreadChatCount: nil,
+            users: nil
         )
     }
 }

--- a/Mogakco/Sources/Data/DataSources/Remote/ChatRoomDataSource.swift
+++ b/Mogakco/Sources/Data/DataSources/Remote/ChatRoomDataSource.swift
@@ -22,6 +22,7 @@ struct ChatRoomDataSource: ChatRoomDataSourceProtocol {
     
     func chats(id: String) -> Observable<Documents<[ChatResponseDTO]>> {
         return provider.request(ChatRoomTarget.chats(id))
+            .catchErrorJustReturn(Documents<[ChatResponseDTO]>(documents: []))
     }
     
     func create(request: CreateChatRoomRequestDTO) -> Observable<ChatRoomResponseDTO> {

--- a/Mogakco/Sources/Domain/Entities/ChatRoom.swift
+++ b/Mogakco/Sources/Domain/Entities/ChatRoom.swift
@@ -14,6 +14,7 @@ struct ChatRoom {
     let userIDs: [String]
     let latestChat: Chat?
     let unreadChatCount: Int?
+    let users: [User]?
 }
 
 extension ChatRoom {
@@ -23,5 +24,15 @@ extension ChatRoom {
         self.userIDs = chatRoom.userIDs
         self.latestChat = latestChat
         self.unreadChatCount = unreadChatCount
+        self.users = nil
+    }
+    
+    init(chatRoom: ChatRoom, users: [User]) {
+        self.id = chatRoom.id
+        self.studyID = chatRoom.studyID
+        self.userIDs = chatRoom.userIDs
+        self.latestChat = chatRoom.latestChat
+        self.unreadChatCount = chatRoom.unreadChatCount
+        self.users = users
     }
 }

--- a/Mogakco/Sources/Domain/UseCases/ChatRoomListUseCase.swift
+++ b/Mogakco/Sources/Domain/UseCases/ChatRoomListUseCase.swift
@@ -31,8 +31,6 @@ struct ChatRoomListUseCase: ChatRoomListUseCaseProtocol {
     func chatRooms() -> Observable<[ChatRoom]> {
         return userRepository
             .load()
-            .flatMap { user in
-                return chatRoomRepository.list(id: user.id, ids: user.chatRoomIDs)
-            }
+            .flatMap { chatRoomRepository.list(id: $0.id, ids: $0.chatRoomIDs) }
     }
 }

--- a/Mogakco/Sources/Presentation/Chat/View/ChatRoomUsersImageView.swift
+++ b/Mogakco/Sources/Presentation/Chat/View/ChatRoomUsersImageView.swift
@@ -1,0 +1,93 @@
+//
+//  ChatRoomUsersImageView.swift
+//  Mogakco
+//
+//  Created by 김범수 on 2022/11/28.
+//  Copyright © 2022 Mogakco. All rights reserved.
+//
+
+import UIKit
+
+final class ChatRoomUsersImageView: UIView {
+    
+    enum Constant {
+        static let imageInset = 1.0
+        static let maxImageCount = 4
+    }
+    
+    private lazy var imageLength: Double = {
+        return self.frame.height / 2.0 - Constant.imageInset
+    }()
+    
+    private lazy var roundImageViews: [RoundProfileImageView] = (0..<Constant.maxImageCount).map { _ in
+        RoundProfileImageView.init(self.imageLength)
+    }
+    
+    private lazy var topHorizontalStackView = UIStackView(arrangedSubviews: [
+        self.roundImageViews[0],
+        self.roundImageViews[1]
+    ]).then {
+        $0.axis = .horizontal
+        $0.spacing = Constant.imageInset
+        $0.distribution = .fillEqually
+        $0.alignment = .fill
+    }
+    
+    private lazy var bottomHorizontalStackView = UIStackView(arrangedSubviews: [
+        self.roundImageViews[2],
+        self.roundImageViews[3]
+    ]).then {
+        $0.axis = .horizontal
+        $0.spacing = Constant.imageInset
+        $0.distribution = .fillEqually
+        $0.alignment = .fill
+    }
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        layout()
+        attribute()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    func configure(imageURLs: [URL]) {
+        zip(imageURLs.shuffled(), roundImageViews).forEach { imageURL, roundImageView in
+            roundImageView.load(url: imageURL)
+        }
+        roundImageViews.enumerated().forEach { index, roundImageView in
+            roundImageView.isHidden = imageURLs.count < index + 1
+        }
+        topHorizontalStackView.isHidden = imageURLs.isEmpty
+        bottomHorizontalStackView.isHidden = imageURLs.count < 3
+    }
+    
+    private func layout() {
+        layoutEntireVerticalStackView()
+    }
+    
+    private func attribute() {
+        layer.cornerRadius = 10.0
+        layer.masksToBounds = true
+    }
+    
+    private func layoutEntireVerticalStackView() {
+        let stackView = createEntireVerticalStackView()
+        addSubview(stackView)
+        stackView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+    }
+    
+    private func createEntireVerticalStackView() -> UIStackView {
+        let arrangedSubviews = [bottomHorizontalStackView, topHorizontalStackView]
+        return UIStackView(arrangedSubviews: arrangedSubviews).then {
+            $0.axis = .vertical
+            $0.spacing = Constant.imageInset
+            $0.distribution = .fillEqually
+            $0.alignment = .fill
+        }
+    }
+}

--- a/Mogakco/Sources/Presentation/Chat/ViewController/ChatListViewController.swift
+++ b/Mogakco/Sources/Presentation/Chat/ViewController/ChatListViewController.swift
@@ -25,7 +25,7 @@ final class ChatListViewController: UIViewController {
     
     private let chatRoomTableView = UITableView().then {
         $0.register(ChatRoomTableViewCell.self, forCellReuseIdentifier: ChatRoomTableViewCell.identifier)
-        $0.rowHeight = ChatRoomTableViewCell.cellHeight
+        $0.rowHeight = ChatRoomTableViewCell.Constant.cellHeight
         $0.backgroundColor = UIColor.mogakcoColor.backgroundDefault
         $0.showsVerticalScrollIndicator = false
         $0.separatorStyle = .none
@@ -62,6 +62,7 @@ final class ChatListViewController: UIViewController {
     
     func bind() {
         let input = ChatListViewModel.Input(
+            viewWillAppear: rx.viewWillAppear.map { _ in }.asObservable(),
             selectedChatRoom: chatRoomTableView.rx.itemSelected.map { _ in }.asObservable()
         )
         let output = viewModel.transform(input: input)

--- a/Mogakco/Sources/Presentation/Chat/ViewModel/ChatListViewModel.swift
+++ b/Mogakco/Sources/Presentation/Chat/ViewModel/ChatListViewModel.swift
@@ -14,6 +14,7 @@ import RxSwift
 final class ChatListViewModel: ViewModel {
     
     struct Input {
+        let viewWillAppear: Observable<Void>
         let selectedChatRoom: Observable<Void>
     }
     
@@ -41,9 +42,9 @@ final class ChatListViewModel: ViewModel {
                 self.coordinator?.showChatDetail()
             })
             .disposed(by: disposeBag)
-
+        
         return Output(
-            chatRoomList: chatRoomListUseCase.chatRooms()
+            chatRoomList: input.viewWillAppear.withUnretained(self).flatMap { $0.0.chatRoomListUseCase.chatRooms() }
         )
     }
 }

--- a/Mogakco/Sources/Presentation/Common/Coordinator/ChatTabCoordinator.swift
+++ b/Mogakco/Sources/Presentation/Common/Coordinator/ChatTabCoordinator.swift
@@ -27,7 +27,8 @@ final class ChatTabCoordinator: Coordinator, ChatTabCoordinatorProtocol {
             coordinator: self,
             chatRoomListUseCase: ChatRoomListUseCase(
                 chatRoomRepository: ChatRoomRepository(
-                    chatRoomDataSource: ChatRoomDataSource(provider: Provider.default)
+                    chatRoomDataSource: ChatRoomDataSource(provider: Provider.default),
+                    remoteUserDataSource: RemoteUserDataSource(provider: Provider.default)
                 ), userRepository: UserRepository(
                     localUserDataSource: UserDefaultsUserDataSource(),
                     remoteUserDataSource: RemoteUserDataSource(provider: Provider.default))

--- a/Mogakco/Sources/Presentation/Profile/ViewController/ProfileViewController.swift
+++ b/Mogakco/Sources/Presentation/Profile/ViewController/ProfileViewController.swift
@@ -103,6 +103,7 @@ final class ProfileViewController: ViewController {
     
     override func bind() {
         let input = ProfileViewModel.Input(
+            viewWillAppear: rx.viewWillAppear.map { _ in }.asObservable(),
             editProfileButtonTapped: profileView.editProfileButton.rx.tap.asObservable(),
             chatButtonTapped: profileView.chatButton.rx.tap.asObservable(),
             hashtagEditButtonTapped: Observable.merge(

--- a/Mogakco/Sources/Presentation/Profile/ViewModel/ProfileViewModel.swift
+++ b/Mogakco/Sources/Presentation/Profile/ViewModel/ProfileViewModel.swift
@@ -28,6 +28,7 @@ final class ProfileViewModel: ViewModel {
     }
     
     struct Input {
+        let viewWillAppear: Observable<Void>
         let editProfileButtonTapped: Observable<Void>
         let chatButtonTapped: Observable<Void>
         let hashtagEditButtonTapped: Observable<KindHashtag>
@@ -66,7 +67,8 @@ final class ProfileViewModel: ViewModel {
         let type = BehaviorSubject<ProfileType>(value: type)
         let isMyProfile = type
             .map { $0 == .current }
-        let user = type
+        let user = input.viewWillAppear
+            .withLatestFrom(type)
             .withUnretained(self)
             .flatMap { viewModel, type -> Observable<User> in
                 switch type {

--- a/Mogakco/Sources/Util/Extension/Date+Formatter.swift
+++ b/Mogakco/Sources/Util/Extension/Date+Formatter.swift
@@ -25,4 +25,18 @@ extension Date {
         formatter.timeZone = TimeZone(abbreviation: "KST")
         return Int(formatter.string(from: self)) ?? 0
     }
+    
+    var relativeTime: String {
+        let formatter = RelativeDateTimeFormatter()
+        formatter.locale = Locale(identifier: "ko_KR")
+        formatter.unitsStyle = .abbreviated
+        return formatter.localizedString(for: self, relativeTo: Date())
+    }
+    
+    func dateToStr() -> String {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyyMMddHHmm"
+        let dateStr = dateFormatter.string(from: self)
+        return dateStr
+    }
 }

--- a/Mogakco/Sources/Util/Extension/Int+Convert.swift
+++ b/Mogakco/Sources/Util/Extension/Int+Convert.swift
@@ -1,0 +1,15 @@
+//
+//  Int+Convert.swift
+//  Mogakco
+//
+//  Created by 김범수 on 2022/11/28.
+//  Copyright © 2022 Mogakco. All rights reserved.
+//
+
+import Foundation
+
+extension Int {
+    var toString: String {
+        return String(self)
+    }
+}

--- a/Mogakco/Sources/Util/Extension/String+Date.swift
+++ b/Mogakco/Sources/Util/Extension/String+Date.swift
@@ -1,0 +1,18 @@
+//
+//  String+Date.swift
+//  Mogakco
+//
+//  Created by 김범수 on 2022/11/28.
+//  Copyright © 2022 Mogakco. All rights reserved.
+//
+
+import Foundation
+
+extension String {
+    func toDate(dateFormat: String) -> Date? {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = dateFormat
+        let date = dateFormatter.date(from: self)
+        return date
+    }
+}


### PR DESCRIPTION
### PR Type

- [x]  기능 추가 🔨
- [ ]  버그 수정 🐞
- [ ]  리팩토링 🚧
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [ ]  테스트 🔍
 

### Related Issue(작업 내용)

- resolves #248 
    - 채팅방 프로필 목록 이미지 구현
    - 최근 메세지 상대 시간으로 표시
    - 최근 메세지 없을 시 예외처리
- resolves #255 
  - 채팅방 목록, 프로필 화면 viewWillAppear 시 리로드

### 참고 사항
채팅방 목록 표시 시 데이터를 순차적으로 받아와 딜레이가 발생합니다. 
해결을 위한 [이슈](https://github.com/boostcampwm-2022/ios04-mogakco/issues/262)를 생성해뒀습니다

### Screenshots(Optional)
<img src="https://user-images.githubusercontent.com/73675540/204210547-26795a7b-c6b7-4a73-8ea6-06a5f7ae5faa.png" width="50%">

