### PR TITLE
HashtagEditViewModel에 EditProfileUseCase 연결

### DIFF
--- a/Mogakco/Sources/Presentation/Common/Coordinator/ProfileTabCoordinator.swift
+++ b/Mogakco/Sources/Presentation/Common/Coordinator/ProfileTabCoordinator.swift
@@ -62,6 +62,6 @@ final class ProfileTabCoordinator: Coordinator, ProfileTabCoordinatorProtocol {
     }
     
     func editFinished() {
-        navigationController.popViewController(animated: true)
+        pop(animated: true)
     }
 }

--- a/Mogakco/Sources/Presentation/Common/Coordinator/ProfileTabCoordinator.swift
+++ b/Mogakco/Sources/Presentation/Common/Coordinator/ProfileTabCoordinator.swift
@@ -60,4 +60,8 @@ final class ProfileTabCoordinator: Coordinator, ProfileTabCoordinatorProtocol {
     
     func showSelectHashtag(kindHashtag: KindHashtag) {
     }
+    
+    func editFinished() {
+        navigationController.popViewController(animated: true)
+    }
 }

--- a/Mogakco/Sources/Presentation/Common/Coordinator/Protocol/ProfileTabCoordinatorProtocol.swift
+++ b/Mogakco/Sources/Presentation/Common/Coordinator/Protocol/ProfileTabCoordinatorProtocol.swift
@@ -13,4 +13,5 @@ protocol ProfileTabCoordinatorProtocol: AnyObject {
     func showEditProfile()
     func showChat()
     func showSelectHashtag(kindHashtag: KindHashtag)
+    func editFinished()
 }

--- a/Mogakco/Sources/Presentation/Profile/View/HashtagListView.swift
+++ b/Mogakco/Sources/Presentation/Profile/View/HashtagListView.swift
@@ -15,7 +15,7 @@ final class HashtagListView: UIView {
     
     let titleLabel = UILabel().then {
         $0.font = UIFont.mogakcoFont.smallBold
-        $0.text = "해시태크"
+        $0.text = "해시태그"
         $0.textColor = UIColor.mogakcoColor.typographyPrimary
     }
     


### PR DESCRIPTION
### PR Type

- [x]  기능 추가 🔨
- [ ]  버그 수정 🐞
- [ ]  리팩토링 🚧
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [ ]  테스트 🔍
 

### Related Issue(작업 내용)

- close #236 
    - 유저 정보에서 해시태그 편집시 서버에 업데이트가 될 수 있도록 UseCase연결

### 참고 사항
- 워낙 UseCase를 잘 만들어두셔서 간단한 연결이었습니다.
- 그런데 프로필 화면에서 편집 화면으로 전환이 아직 안되는듯 합니다!
