### PR TITLE
JoinStudyUseCase 구현

### DIFF
--- a/Mogakco/Sources/Data/DataSources/Protocol/ChatRoomDataSourceProtocol.swift
+++ b/Mogakco/Sources/Data/DataSources/Protocol/ChatRoomDataSourceProtocol.swift
@@ -10,6 +10,7 @@ import RxSwift
 
 protocol ChatRoomDataSourceProtocol {
     func list() -> Observable<Documents<[ChatRoomResponseDTO]>>
+    func detail(id: String) -> Observable<ChatRoomResponseDTO>
     func chats(id: String) -> Observable<Documents<[ChatResponseDTO]>>
     func create(request: CreateChatRoomRequestDTO) -> Observable<ChatRoomResponseDTO>
     func updateIDs(id: String, request: UpdateUserIDsRequestDTO) -> Observable<ChatRoomResponseDTO>

--- a/Mogakco/Sources/Data/DataSources/Remote/ChatRoomDataSource.swift
+++ b/Mogakco/Sources/Data/DataSources/Remote/ChatRoomDataSource.swift
@@ -20,6 +20,10 @@ struct ChatRoomDataSource: ChatRoomDataSourceProtocol {
         return provider.request(ChatRoomTarget.list)
     }
     
+    func detail(id: String) -> Observable<ChatRoomResponseDTO> {
+        return provider.request(ChatRoomTarget.detail(id))
+    }
+    
     func chats(id: String) -> Observable<Documents<[ChatResponseDTO]>> {
         return provider.request(ChatRoomTarget.chats(id))
             .catchAndReturn(Documents<[ChatResponseDTO]>(documents: []))
@@ -36,6 +40,7 @@ struct ChatRoomDataSource: ChatRoomDataSourceProtocol {
 
 enum ChatRoomTarget {
     case list
+    case detail(String)
     case chats(String)
     case create(CreateChatRoomRequestDTO)
     case updateIDs(String, UpdateUserIDsRequestDTO)
@@ -48,7 +53,7 @@ extension ChatRoomTarget: TargetType {
     
     var method: HTTPMethod {
         switch self {
-        case .list, .chats:
+        case .list, .detail, .chats:
             return .get
         case .create:
             return .post
@@ -67,6 +72,8 @@ extension ChatRoomTarget: TargetType {
         switch self {
         case .list:
             return ""
+        case .detail(let id):
+            return "/\(id)"
         case let .chats(id):
             return "/\(id)/chats"
         case let .create(request):
@@ -79,7 +86,7 @@ extension ChatRoomTarget: TargetType {
     
     var parameters: RequestParams? {
         switch self {
-        case .list, .chats:
+        case .list, .detail, .chats:
             return nil
         case let .create(request):
             return .body(request)

--- a/Mogakco/Sources/Data/Repositories/ChatRoomRepository.swift
+++ b/Mogakco/Sources/Data/Repositories/ChatRoomRepository.swift
@@ -79,6 +79,11 @@ struct ChatRoomRepository: ChatRoomRepositoryProtocol {
            }
     }
     
+    func detail(id: String) -> Observable<ChatRoom> {
+        return chatRoomDataSource.detail(id: id)
+            .map { $0.toDomain() }
+    }
+    
     func updateIDs(id: String, userIDs: [String]) -> Observable<ChatRoom> {
         let updateDTO = UpdateUserIDsRequestDTO(userIDs: userIDs)
         return chatRoomDataSource.updateIDs(id: id, request: updateDTO)

--- a/Mogakco/Sources/Data/Repositories/StudyRepository.swift
+++ b/Mogakco/Sources/Data/Repositories/StudyRepository.swift
@@ -9,7 +9,11 @@
 import RxSwift
 
 struct StudyRepository: StudyRepositoryProtocol {
-
+    
+    enum StudyRepositoryError: Error {
+        case max
+    }
+    
     private let studyDataSource: StudyDataSourceProtocol
     private let localUserDataSource: LocalUserDataSourceProtocol
     private let remoteUserDataSource: RemoteUserDataSourceProtocol
@@ -119,9 +123,9 @@ struct StudyRepository: StudyRepositoryProtocol {
             .map { $0.toDomain() }
     }
     
-    func join(id: String) -> Observable<Bool> {
+    func join(id: String) -> Observable<Void> {
         
-        return Observable<Bool>.create { emitter in
+        return Observable<Void>.create { emitter in
             
             let canJoinStudy = Observable
                 .zip(
@@ -131,7 +135,7 @@ struct StudyRepository: StudyRepositoryProtocol {
                 .do(onNext: { user, study in
                     if study.userIDs.count >= study.maxUserCount &&
                       !study.userIDs.contains(user.id) {
-                        emitter.onNext(false)
+                        emitter.onError(StudyRepositoryError.max)
                     }
                 })
                 .filter { user, study in
@@ -191,7 +195,7 @@ struct StudyRepository: StudyRepositoryProtocol {
                     updateChatRoom
                 )
                 .subscribe { _ in
-                    emitter.onNext(true)
+                    emitter.onNext(())
                 }
                 .disposed(by: self.disposeBag)
             

--- a/Mogakco/Sources/Domain/Repositories/ChatRoomRepositoryProtocol.swift
+++ b/Mogakco/Sources/Domain/Repositories/ChatRoomRepositoryProtocol.swift
@@ -10,6 +10,7 @@ import RxSwift
 
 protocol ChatRoomRepositoryProtocol {
     func list(id: String, ids: [String]) -> Observable<[ChatRoom]>
+    func detail(id: String) -> Observable<ChatRoom>
     func create(studyID: String?, userIDs: [String]) -> Observable<ChatRoom>
     func updateIDs(id: String, userIDs: [String]) -> Observable<ChatRoom>
 }

--- a/Mogakco/Sources/Domain/Repositories/StudyRepositoryProtocol.swift
+++ b/Mogakco/Sources/Domain/Repositories/StudyRepositoryProtocol.swift
@@ -14,5 +14,5 @@ protocol StudyRepositoryProtocol {
     func detail(id: String) -> Observable<Study>
     func create(study: Study) -> Observable<Study>
     func updateIDs(id: String, userIDs: [String]) -> Observable<Study>
-    func join(id: String) -> Observable<Bool>
+    func join(id: String) -> Observable<Void>
 }

--- a/Mogakco/Sources/Domain/Repositories/StudyRepositoryProtocol.swift
+++ b/Mogakco/Sources/Domain/Repositories/StudyRepositoryProtocol.swift
@@ -14,4 +14,5 @@ protocol StudyRepositoryProtocol {
     func detail(id: String) -> Observable<Study>
     func create(study: Study) -> Observable<Study>
     func updateIDs(id: String, userIDs: [String]) -> Observable<Study>
+    func join(id: String) -> Observable<Bool>
 }

--- a/Mogakco/Sources/Domain/UseCases/JoinStudyUseCase.swift
+++ b/Mogakco/Sources/Domain/UseCases/JoinStudyUseCase.swift
@@ -10,99 +10,30 @@ import Foundation
 
 import RxSwift
 
-class JoinStudyUseCase: JoinStudyUseCaseProtocol {
+struct JoinStudyUseCase: JoinStudyUseCaseProtocol {
     
     enum JoinStudyUseCaseError: Error, LocalizedError {
         case max
     }
     
     private let studyRepository: StudyRepositoryProtocol
-    private let chatRoomRepository: ChatRoomRepositoryProtocol
-    private let userRepository: UserRepositoryProtocol
     private let disposeBag = DisposeBag()
     
-    init(
-        studyRepository: StudyRepositoryProtocol,
-        chatRoomRepository: ChatRoomRepositoryProtocol,
-        userRepository: UserRepositoryProtocol
-    ) {
+    init(studyRepository: StudyRepositoryProtocol) {
         self.studyRepository = studyRepository
-        self.chatRoomRepository = chatRoomRepository
-        self.userRepository = userRepository
     }
     
     func join(id: String) -> Observable<Void> {
-        
-        return Observable<Void>.create { [weak self] emitter in
-            
-            guard let self = self else { return Disposables.create() }
-            
-            let canJoinStudy = Observable
-                .zip(
-                    self.userRepository.load(),
-                    self.studyRepository.detail(id: id)
-                )
-                .do(onNext: { user, study in
-                    if study.userIDs.count >= study.maxUserCount &&
-                      !study.userIDs.contains(user.id) {
+        return Observable<Void>.create { emitter in
+            studyRepository.join(id: id)
+                .subscribe { result in
+                    if result {
+                        emitter.onNext(())
+                    } else {
                         emitter.onError(JoinStudyUseCaseError.max)
                     }
-                })
-                .filter { user, study in
-                    return study.userIDs.count < study.maxUserCount ||
-                        study.userIDs.contains(user.id)
                 }
-            
-            let user = canJoinStudy
-                .flatMap { _ in self.userRepository.load() }
-            
-            let updateUser = user
-                .flatMap { user in
-                    self.userRepository.updateIDs(
-                        id: user.id,
-                        chatRoomIDs: Array(Set(user.chatRoomIDs + [id])),
-                        studyIDs: Array(Set(user.studyIDs + [id]))
-                    )
-                }
-                .flatMap { user in
-                    self.userRepository.save(user: user)
-                }
-
-            let updateStudy = Observable
-                .zip(
-                    user,
-                    self.studyRepository.detail(id: id)
-                )
-                .flatMap { data in
-                    self.studyRepository.updateIDs(
-                        id: data.1.id,
-                        userIDs: Array(Set(data.1.userIDs + [data.0.id]))
-                    )
-                }
-
-            let updateChatRoom = Observable
-                .zip(
-                    user,
-                    self.chatRoomRepository.detail(id: id)
-                )
-                .flatMap { data in
-                    self.chatRoomRepository.updateIDs(
-                        id: data.1.id,
-                        userIDs: Array(Set(data.1.userIDs + [data.0.id]))
-                    )
-                }
-
-            Observable
-                .zip(
-                    updateUser,
-                    updateStudy,
-                    updateChatRoom
-                )
-                .subscribe { _ in
-                    emitter.onNext(())
-                }
-                .disposed(by: self.disposeBag)
-            
+                .disposed(by: disposeBag)
             return Disposables.create()
         }
     }

--- a/Mogakco/Sources/Domain/UseCases/JoinStudyUseCase.swift
+++ b/Mogakco/Sources/Domain/UseCases/JoinStudyUseCase.swift
@@ -1,0 +1,109 @@
+//
+//  JoinStudyUseCase.swift
+//  Mogakco
+//
+//  Created by 신소민 on 2022/11/28.
+//  Copyright © 2022 Mogakco. All rights reserved.
+//
+
+import Foundation
+
+import RxSwift
+
+class JoinStudyUseCase: JoinStudyUseCaseProtocol {
+    
+    enum JoinStudyUseCaseError: Error, LocalizedError {
+        case max
+    }
+    
+    private let studyRepository: StudyRepositoryProtocol
+    private let chatRoomRepository: ChatRoomRepositoryProtocol
+    private let userRepository: UserRepositoryProtocol
+    private let disposeBag = DisposeBag()
+    
+    init(
+        studyRepository: StudyRepositoryProtocol,
+        chatRoomRepository: ChatRoomRepositoryProtocol,
+        userRepository: UserRepositoryProtocol
+    ) {
+        self.studyRepository = studyRepository
+        self.chatRoomRepository = chatRoomRepository
+        self.userRepository = userRepository
+    }
+    
+    func join(id: String) -> Observable<Void> {
+        
+        return Observable<Void>.create { [weak self] emitter in
+            
+            guard let self = self else { return Disposables.create() }
+            
+            let canJoinStudy = Observable
+                .zip(
+                    self.userRepository.load(),
+                    self.studyRepository.detail(id: id)
+                )
+                .do(onNext: { user, study in
+                    if study.userIDs.count >= study.maxUserCount &&
+                      !study.userIDs.contains(user.id) {
+                        emitter.onError(JoinStudyUseCaseError.max)
+                    }
+                })
+                .filter { user, study in
+                    return study.userIDs.count < study.maxUserCount ||
+                        study.userIDs.contains(user.id)
+                }
+            
+            let user = canJoinStudy
+                .flatMap { _ in self.userRepository.load() }
+            
+            let updateUser = user
+                .flatMap { user in
+                    self.userRepository.updateIDs(
+                        id: user.id,
+                        chatRoomIDs: Array(Set(user.chatRoomIDs + [id])),
+                        studyIDs: Array(Set(user.studyIDs + [id]))
+                    )
+                }
+                .flatMap { user in
+                    self.userRepository.save(user: user)
+                }
+
+            let updateStudy = Observable
+                .zip(
+                    user,
+                    self.studyRepository.detail(id: id)
+                )
+                .flatMap { data in
+                    self.studyRepository.updateIDs(
+                        id: data.1.id,
+                        userIDs: Array(Set(data.1.userIDs + [data.0.id]))
+                    )
+                }
+
+            let updateChatRoom = Observable
+                .zip(
+                    user,
+                    self.chatRoomRepository.detail(id: id)
+                )
+                .flatMap { data in
+                    self.chatRoomRepository.updateIDs(
+                        id: data.1.id,
+                        userIDs: Array(Set(data.1.userIDs + [data.0.id]))
+                    )
+                }
+
+            Observable
+                .zip(
+                    updateUser,
+                    updateStudy,
+                    updateChatRoom
+                )
+                .subscribe { _ in
+                    emitter.onNext(())
+                }
+                .disposed(by: self.disposeBag)
+            
+            return Disposables.create()
+        }
+    }
+}

--- a/Mogakco/Sources/Domain/UseCases/JoinStudyUseCase.swift
+++ b/Mogakco/Sources/Domain/UseCases/JoinStudyUseCase.swift
@@ -26,13 +26,11 @@ struct JoinStudyUseCase: JoinStudyUseCaseProtocol {
     func join(id: String) -> Observable<Void> {
         return Observable<Void>.create { emitter in
             studyRepository.join(id: id)
-                .subscribe { result in
-                    if result {
-                        emitter.onNext(())
-                    } else {
-                        emitter.onError(JoinStudyUseCaseError.max)
-                    }
-                }
+                .subscribe(onNext: {
+                    emitter.onNext($0)
+                }, onError: { _ in
+                    emitter.onError(JoinStudyUseCaseError.max)
+                })
                 .disposed(by: disposeBag)
             return Disposables.create()
         }

--- a/Mogakco/Sources/Domain/UseCases/Protocol/JoinStudyUseCaseProtocol.swift
+++ b/Mogakco/Sources/Domain/UseCases/Protocol/JoinStudyUseCaseProtocol.swift
@@ -1,0 +1,13 @@
+//
+//  JoinStudyUseCaseProtocol.swift
+//  Mogakco
+//
+//  Created by 신소민 on 2022/11/28.
+//  Copyright © 2022 Mogakco. All rights reserved.
+//
+
+import RxSwift
+
+protocol JoinStudyUseCaseProtocol {
+    func join(id: String) -> Observable<Void>
+}

--- a/Mogakco/Sources/Presentation/Common/Coordinator/StudyTabCoordinator.swift
+++ b/Mogakco/Sources/Presentation/Common/Coordinator/StudyTabCoordinator.swift
@@ -64,11 +64,7 @@ final class StudyTabCoordinator: Coordinator, StudyTabCoordinatorProtocol {
             remoteUserDataSource: remoteUserDataSource
         )
         let userUseCase = UserUseCase(userRepository: userRepository, studyRepository: studyRepository)
-        let joinStudyUseCase = JoinStudyUseCase(
-            studyRepository: studyRepository,
-            chatRoomRepository: chatRoomRepository,
-            userRepository: userRepository
-        )
+        let joinStudyUseCase = JoinStudyUseCase(studyRepository: studyRepository)
         
         let viewModel = StudyDetailViewModel(
             studyID: id,

--- a/Mogakco/Sources/Presentation/Common/Coordinator/StudyTabCoordinator.swift
+++ b/Mogakco/Sources/Presentation/Common/Coordinator/StudyTabCoordinator.swift
@@ -59,14 +59,24 @@ final class StudyTabCoordinator: Coordinator, StudyTabCoordinatorProtocol {
             localUserDataSource: localUserDataSource,
             remoteUserDataSource: remoteUserDataSource
         )
+        let chatRoomRepository = ChatRoomRepository(
+            chatRoomDataSource: ChatRoomDataSource(provider: Provider.default),
+            remoteUserDataSource: remoteUserDataSource
+        )
         let userUseCase = UserUseCase(userRepository: userRepository, studyRepository: studyRepository)
+        let joinStudyUseCase = JoinStudyUseCase(
+            studyRepository: studyRepository,
+            chatRoomRepository: chatRoomRepository,
+            userRepository: userRepository
+        )
         
         let viewModel = StudyDetailViewModel(
             studyID: id,
             coordinator: self,
             studyUsecase: studyUseCase,
             hashtagUseCase: hashtagUseCase,
-            userUseCase: userUseCase
+            userUseCase: userUseCase,
+            joinStudyUseCase: joinStudyUseCase
         )
         let viewController = StudyDetailViewController(viewModel: viewModel)
         navigationController.tabBarController?.navigationController?.pushViewController(viewController, animated: true)

--- a/Mogakco/Sources/Presentation/Common/Coordinator/StudyTabCoordinator.swift
+++ b/Mogakco/Sources/Presentation/Common/Coordinator/StudyTabCoordinator.swift
@@ -40,7 +40,6 @@ final class StudyTabCoordinator: Coordinator, StudyTabCoordinatorProtocol {
     }
     
     func showStudyDetail(id: String) {
-        let studyDataSource = StudyDataSource(provider: Provider.default)
         let studyRepository = StudyRepository(
             studyDataSource: StudyDataSource(provider: Provider.default),
             localUserDataSource: UserDefaultsUserDataSource(),
@@ -59,10 +58,7 @@ final class StudyTabCoordinator: Coordinator, StudyTabCoordinatorProtocol {
             localUserDataSource: localUserDataSource,
             remoteUserDataSource: remoteUserDataSource
         )
-        let chatRoomRepository = ChatRoomRepository(
-            chatRoomDataSource: ChatRoomDataSource(provider: Provider.default),
-            remoteUserDataSource: remoteUserDataSource
-        )
+
         let userUseCase = UserUseCase(userRepository: userRepository, studyRepository: studyRepository)
         let joinStudyUseCase = JoinStudyUseCase(studyRepository: studyRepository)
         
@@ -74,6 +70,7 @@ final class StudyTabCoordinator: Coordinator, StudyTabCoordinatorProtocol {
             userUseCase: userUseCase,
             joinStudyUseCase: joinStudyUseCase
         )
+        
         let viewController = StudyDetailViewController(viewModel: viewModel)
         navigationController.tabBarController?.navigationController?.pushViewController(viewController, animated: true)
     }
@@ -116,7 +113,10 @@ final class StudyTabCoordinator: Coordinator, StudyTabCoordinatorProtocol {
             chatRoomID: chatRoomID
         )
         let chatViewController = ChatViewController(viewModel: viewModel)
-        navigationController.pushViewController(chatViewController, animated: true)
+        navigationController.tabBarController?.navigationController?.pushViewController(
+            chatViewController,
+            animated: true
+        )
     }
     
     func showCategorySelect(delegate: HashtagSelectProtocol?) {

--- a/Mogakco/Sources/Presentation/Study/ViewModel/StudyDetailViewModel.swift
+++ b/Mogakco/Sources/Presentation/Study/ViewModel/StudyDetailViewModel.swift
@@ -29,6 +29,8 @@ final class StudyDetailViewModel: ViewModel {
     private let studyUseCase: StudyDetailUseCaseProtocol
     private let hashtagUseCase: HashtagUseCaseProtocol
     private let userUseCase: UserUseCaseProtocol
+    private let joinStudyUseCase: JoinStudyUseCaseProtocol
+    
     var languages = BehaviorSubject<[Hashtag]>(value: [])
     var participants = BehaviorSubject<[User]>(value: [])
     
@@ -45,13 +47,15 @@ final class StudyDetailViewModel: ViewModel {
         coordinator: StudyTabCoordinatorProtocol,
         studyUsecase: StudyDetailUseCaseProtocol,
         hashtagUseCase: HashtagUseCaseProtocol,
-        userUseCase: UserUseCaseProtocol
+        userUseCase: UserUseCaseProtocol,
+        joinStudyUseCase: JoinStudyUseCase
     ) {
         self.studyID = studyID
         self.coordinator = coordinator
         self.studyUseCase = studyUsecase
         self.hashtagUseCase = hashtagUseCase
         self.userUseCase = userUseCase
+        self.joinStudyUseCase = joinStudyUseCase
     }
     
     func transform(input: Input) -> Output {
@@ -102,9 +106,17 @@ final class StudyDetailViewModel: ViewModel {
         
         
         input.studyJoinButtonTapped
-            .subscribe(onNext: {
-                // TODO: 스터디 참가 API 바인딩 - studyUseCase -> JoinStudy()
-                self.coordinator.showChatDetail(chatRoomID: self.studyID)
+            .withUnretained(self)
+            .flatMap { viewModel, _ in
+                viewModel.joinStudyUseCase.join(id: viewModel.studyID)
+            }
+            .withUnretained(self)
+            .subscribe(onNext: { viewModel, _ in
+                // TODO: 채팅방 화면 띄우기
+                viewModel.coordinator.showChatDetail(chatRoomID: viewModel.studyID)
+            }, onError: { error in
+                // TODO: 채팅방 인원이 다 찼을 때 예외처리
+                print("👀:", error)
             })
             .disposed(by: disposeBag)
         

--- a/Mogakco/Sources/Presentation/Study/ViewModel/StudyDetailViewModel.swift
+++ b/Mogakco/Sources/Presentation/Study/ViewModel/StudyDetailViewModel.swift
@@ -104,16 +104,15 @@ final class StudyDetailViewModel: ViewModel {
             })
             .disposed(by: disposeBag)
         
-        
         input.studyJoinButtonTapped
             .withUnretained(self)
-            .flatMap { viewModel, _ in
-                viewModel.joinStudyUseCase.join(id: viewModel.studyID)
+            .flatMap {
+                $0.0.joinStudyUseCase.join(id: $0.0.studyID)
             }
             .withUnretained(self)
-            .subscribe(onNext: { viewModel, _ in
+            .subscribe(onNext: { _ in
                 // TODO: 채팅방 화면 띄우기
-                viewModel.coordinator.showChatDetail(chatRoomID: viewModel.studyID)
+                
             }, onError: { error in
                 // TODO: 채팅방 인원이 다 찼을 때 예외처리
                 print("👀:", error)


### PR DESCRIPTION
### PR Type

- [X]  기능 추가 🔨
- [ ]  버그 수정 🐞
- [ ]  리팩토링 🚧
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [ ]  테스트 🔍
 

### Related Issue(작업 내용)

> 이슈 번호와 구현 내용 및 작업 했던 내역을 입력해주세요!
> 
- close #249
    - 스터디 참가 API를 구현했습니다.

      * 스터디가 꽉 찼는지 판별 (study.userIDs.count < study.maxUserCount)

      * User 데이터 불러오기 >>> 이미 만들어진 User의 chatRoomIds, studyIds 업데이트 >>> 로컬에 반영
    
      * Study 데이터 불러오기 >>> 이미 만들어진 Study 데이터의 userIDs 업데이트 (사용자 아이디 필요)
    
      * ChatRoom 데이터 불러오기 >>> 이미 만들어진 ChatRoom의 userIDs 업데이트 (사용자 아이디 필요)

### 참고 사항

* 스터디가 꽉 찼을 때는 JoinStudyUseCase.max 에러를 던지도록 구현했습니다. -> 이와 관련한 UI 처리 [이슈](https://github.com/boostcampwm-2022/iOS04-Mogakco/issues/270#issue-1465981000)를 생성했습니다.
* User, Study, ChatRoom의 필드를 업데이트 하기 전에 한 번씩 불러와야 해서 코드가 복잡합니다. 개선방향이 있다면 말씀해주세요.