### PR TITLE
프로필 해시태그, 스터디 목록 없을 시 대응 UI 구성

### DIFF
--- a/Mogakco/Sources/Data/DataSources/Remote/ChatRoomDataSource.swift
+++ b/Mogakco/Sources/Data/DataSources/Remote/ChatRoomDataSource.swift
@@ -22,7 +22,7 @@ struct ChatRoomDataSource: ChatRoomDataSourceProtocol {
     
     func chats(id: String) -> Observable<Documents<[ChatResponseDTO]>> {
         return provider.request(ChatRoomTarget.chats(id))
-            .catchErrorJustReturn(Documents<[ChatResponseDTO]>(documents: []))
+            .catchAndReturn(Documents<[ChatResponseDTO]>(documents: []))
     }
     
     func create(request: CreateChatRoomRequestDTO) -> Observable<ChatRoomResponseDTO> {

--- a/Mogakco/Sources/Domain/UseCases/Protocol/UserUseCaseProtocol.swift
+++ b/Mogakco/Sources/Domain/UseCases/Protocol/UserUseCaseProtocol.swift
@@ -12,5 +12,5 @@ protocol UserUseCaseProtocol {
     func user(id: String) -> Observable<User>
     func users(ids: [String]) -> Observable<[User]>
     func myProfile() -> Observable<User>
-    func myStudyRatingList() -> Observable<[(String, Int)]>
+    func studyRatingList(studyIDs: [String]) -> Observable<[(String, Int)]>
 }

--- a/Mogakco/Sources/Domain/UseCases/UserUseCase.swift
+++ b/Mogakco/Sources/Domain/UseCases/UserUseCase.swift
@@ -46,10 +46,8 @@ struct UserUseCase: UserUseCaseProtocol {
             })
     }
     
-    func myStudyRatingList() -> Observable<[(String, Int)]> {
-        return userRepository.load()
-            .map { $0.studyIDs }
-            .flatMap { studyRepository.list(ids: $0) }
+    func studyRatingList(studyIDs: [String]) -> Observable<[(String, Int)]> {
+        return studyRepository.list(ids: studyIDs)
             .map { $0.map { $0.category } }
             .map { $0.countDictionary }
             .map { $0.sorted { $0.value < $1.value }.map { ($0.key, $0.value) } }

--- a/Mogakco/Sources/Presentation/Chat/ViewController/ChatListViewController.swift
+++ b/Mogakco/Sources/Presentation/Chat/ViewController/ChatListViewController.swift
@@ -16,7 +16,7 @@ final class ChatListViewController: UIViewController {
     
     enum Constant {
         static let headerViewTitle = "채팅 목록"
-        static let headerViewHeight = 68.0
+        static let headerViewHeight = Layout.tapbarHeaderViewHeight
     }
     
     private let headerView = TitleHeaderView().then {

--- a/Mogakco/Sources/Presentation/Common/Coordinator/Protocol/Coordinator.swift
+++ b/Mogakco/Sources/Presentation/Common/Coordinator/Protocol/Coordinator.swift
@@ -23,4 +23,8 @@ extension Coordinator {
     func pop(animated: Bool) {
         navigationController.popViewController(animated: animated)
     }
+    
+    func popTabbar(animated: Bool) {
+        navigationController.tabBarController?.navigationController?.popViewController(animated: animated) 
+    }
 }

--- a/Mogakco/Sources/Presentation/Profile/View/HashtagListView.swift
+++ b/Mogakco/Sources/Presentation/Profile/View/HashtagListView.swift
@@ -14,12 +14,12 @@ import RxSwift
 final class HashtagListView: UIView {
     
     enum Constant {
+        static let emtpyText = "편집 버튼을 눌러 나만의 해시태크를 설정해보세요"
         static let editButtonSize = CGSize(width: 45.0, height: 22.0)
     }
     
     let titleLabel = UILabel().then {
         $0.font = UIFont.mogakcoFont.smallBold
-        $0.text = "해시태그"
         $0.textColor = UIColor.mogakcoColor.typographyPrimary
     }
     
@@ -54,7 +54,7 @@ final class HashtagListView: UIView {
     }
     
     private let emptyLabel = UILabel().then {
-        $0.text = "편집 버튼을 눌러 나만의 해시태크를 설정해보세요!"
+        $0.text = Constant.emtpyText
         $0.font = .mogakcoFont.caption
         $0.textColor = .mogakcoColor.typographyPrimary
         $0.textAlignment = .center

--- a/Mogakco/Sources/Presentation/Profile/View/HashtagListView.swift
+++ b/Mogakco/Sources/Presentation/Profile/View/HashtagListView.swift
@@ -71,15 +71,15 @@ final class HashtagListView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
     
-    func bind(hashtags: Driver<[String]>) {
+    func bind(hashtags: Driver<[Hashtag]>) {
         hashtags
-            .drive(hashtagCollectionView.rx.items) { collectionView, index, language in
+            .drive(hashtagCollectionView.rx.items) { collectionView, index, hashtag in
                 guard let cell = collectionView.dequeueReusableCell(
-                    withReuseIdentifier: BadgeCell.identifier,
-                    for: IndexPath(row: index, section: 0)) as? BadgeCell else {
+                    withReuseIdentifier: HashtagBadgeCell.identifier,
+                    for: IndexPath(row: index, section: 0)) as? HashtagBadgeCell else {
                     return UICollectionViewCell()
                 }
-                cell.setInfo(iconName: language, title: language)
+                cell.setHashtag(hashtag: hashtag)
                 return cell
             }
             .disposed(by: disposeBag)

--- a/Mogakco/Sources/Presentation/Profile/View/ProfileView.swift
+++ b/Mogakco/Sources/Presentation/Profile/View/ProfileView.swift
@@ -72,7 +72,6 @@ final class ProfileView: UIView {
     
     private func layoutRoundProfileImageView() {
         addSubview(roundProfileImageView)
-        
         roundProfileImageView.snp.makeConstraints {
             $0.leading.equalToSuperview().inset(16.0)
             $0.top.equalToSuperview().offset(16.0)
@@ -81,7 +80,6 @@ final class ProfileView: UIView {
     
     private func layoutRoundLanguageImageView() {
         addSubview(roundLanguageImageView)
-        
         roundLanguageImageView.snp.makeConstraints {
             $0.center.equalTo(roundProfileImageView).offset(40.0)
         }

--- a/Mogakco/Sources/Presentation/Profile/View/ProfileView.swift
+++ b/Mogakco/Sources/Presentation/Profile/View/ProfileView.swift
@@ -46,8 +46,8 @@ final class ProfileView: UIView {
     }
     
     let editProfileButton = UIButton().then {
-        $0.addShadow(offset: .init(width: 5.0, height: 5.0))
-        $0.layer.cornerRadius = 12.0
+        $0.addShadow(offset: .init(width: 3.0, height: 3.0))
+        $0.layer.cornerRadius = 14.0
         $0.setTitle("프로필 편집", for: .normal)
         $0.setTitleColor(UIColor.mogakcoColor.typographyPrimary, for: .normal)
         $0.titleLabel?.font = UIFont.mogakcoFont.smallBold

--- a/Mogakco/Sources/Presentation/Profile/View/StudyRatingListView.swift
+++ b/Mogakco/Sources/Presentation/Profile/View/StudyRatingListView.swift
@@ -16,9 +16,12 @@ class StudyRatingListView: UIView {
     }
     
     private let titleLabel = UILabel().then {
-        $0.text = "스터디 참여 top3"
+        $0.text = "스터디 참여 Top3"
         $0.font = .mogakcoFont.mediumBold
         $0.textColor = .mogakcoColor.typographyPrimary
+        $0.snp.makeConstraints {
+            $0.height.equalTo(Constant.studyRatingViewHeight)
+        }
     }
 
     private let firstStudyRatingView = StudyRatingView().then {
@@ -34,6 +37,16 @@ class StudyRatingListView: UIView {
     }
     
     private let thirdStudyRatingView = StudyRatingView().then {
+        $0.snp.makeConstraints {
+            $0.height.equalTo(Constant.studyRatingViewHeight)
+        }
+    }
+    
+    private let emptyLabel = UILabel().then {
+        $0.text = "아직 참여한 스터디가 없어요"
+        $0.font = .mogakcoFont.caption
+        $0.textColor = .mogakcoColor.typographyPrimary
+        $0.textAlignment = .center
         $0.snp.makeConstraints {
             $0.height.equalTo(Constant.studyRatingViewHeight)
         }
@@ -54,10 +67,10 @@ class StudyRatingListView: UIView {
         zip(studyRatingList, studyRatingViews).forEach { studyRating, studyRatingView in
             studyRatingView.configure(studyRating: studyRating)
         }
-        isHidden = studyRatingList.isEmpty
         firstStudyRatingView.isHidden = studyRatingList.count < 1
         secondStudyRatingView.isHidden = studyRatingList.count < 2
         thirdStudyRatingView.isHidden = studyRatingList.count < 3
+        emptyLabel.isHidden = !studyRatingList.isEmpty
     }
 
     private func layout() {
@@ -69,7 +82,14 @@ class StudyRatingListView: UIView {
     }
     
     private func makeEntireStackView() -> UIStackView {
-        let arrangeViews = [titleLabel, firstStudyRatingView, secondStudyRatingView, thirdStudyRatingView]
+        let arrangeViews = [
+            titleLabel,
+            firstStudyRatingView,
+            secondStudyRatingView,
+            thirdStudyRatingView,
+            emptyLabel,
+            UIView()
+        ]
         return UIStackView(arrangedSubviews: arrangeViews).then {
             $0.axis = .vertical
             $0.spacing = 4.0
@@ -77,4 +97,6 @@ class StudyRatingListView: UIView {
             $0.isLayoutMarginsRelativeArrangement = true
         }
     }
+    
+    
 }

--- a/Mogakco/Sources/Presentation/Profile/View/StudyRatingListView.swift
+++ b/Mogakco/Sources/Presentation/Profile/View/StudyRatingListView.swift
@@ -12,11 +12,13 @@ import UIKit
 class StudyRatingListView: UIView {
     
     enum Constant {
+        static let studyRatingListTitle = "스터디 참여 Top3"
+        static let emptyText = "아직 참여한 스터디가 없어요"
         static let studyRatingViewHeight = 40.0
     }
     
     private let titleLabel = UILabel().then {
-        $0.text = "스터디 참여 Top3"
+        $0.text = Constant.studyRatingListTitle
         $0.font = .mogakcoFont.mediumBold
         $0.textColor = .mogakcoColor.typographyPrimary
         $0.snp.makeConstraints {
@@ -43,7 +45,7 @@ class StudyRatingListView: UIView {
     }
     
     private let emptyLabel = UILabel().then {
-        $0.text = "아직 참여한 스터디가 없어요"
+        $0.text = Constant.emptyText
         $0.font = .mogakcoFont.caption
         $0.textColor = .mogakcoColor.typographyPrimary
         $0.textAlignment = .center
@@ -97,6 +99,4 @@ class StudyRatingListView: UIView {
             $0.isLayoutMarginsRelativeArrangement = true
         }
     }
-    
-    
 }

--- a/Mogakco/Sources/Presentation/Profile/View/StudyRatingView.swift
+++ b/Mogakco/Sources/Presentation/Profile/View/StudyRatingView.swift
@@ -16,14 +16,12 @@ class StudyRatingView: UIView {
         $0.font = .mogakcoFont.smallBold
         $0.textColor = .mogakcoColor.typographyPrimary
         $0.textAlignment = .left
-        $0.text = "알고리즘 스터디"
     }
 
     private lazy var countLabel = UILabel().then {
         $0.font = .mogakcoFont.smallBold
         $0.textColor = .mogakcoColor.typographyPrimary
         $0.textAlignment = .right
-        $0.text = "+33"
     }
 
     private let bag = DisposeBag()

--- a/Mogakco/Sources/Presentation/Profile/ViewController/ProfileViewController.swift
+++ b/Mogakco/Sources/Presentation/Profile/ViewController/ProfileViewController.swift
@@ -14,10 +14,14 @@ final class ProfileViewController: ViewController {
 
     enum Constant {
         static let headerViewTitle = "프로필"
+        static let languageHashtagListViewTitle = "언어"
+        static let careerHashtagListViewTitle = "경력"
+        static let categoryHashtagListViewTitle = "카테고리"
         static let headerViewHeight = 68.0
         static let profileViewHeight = 200.0
         static let hashtagViewHeight = 100.0
         static let studyRatingListView = 200.0
+        static let bottomMarginViewHeight = 60.0
     }
     
     private let scrollView = UIScrollView().then {
@@ -31,7 +35,7 @@ final class ProfileViewController: ViewController {
         self.careerListView,
         self.categoryListView,
         self.studyRatingListView,
-        self.marginView
+        self.bottomMarginView
     ]).then {
         $0.spacing = 4.0
         $0.axis = .vertical
@@ -48,21 +52,21 @@ final class ProfileViewController: ViewController {
     }
     
     private let languageListView = HashtagListView().then {
-        $0.titleLabel.text = "언어"
+        $0.titleLabel.text = Constant.languageHashtagListViewTitle
         $0.snp.makeConstraints {
             $0.height.equalTo(Constant.hashtagViewHeight)
         }
     }
     
     private let careerListView = HashtagListView().then {
-        $0.titleLabel.text = "경력"
+        $0.titleLabel.text = Constant.careerHashtagListViewTitle
         $0.snp.makeConstraints {
             $0.height.equalTo(Constant.hashtagViewHeight)
         }
     }
     
     private let categoryListView = HashtagListView().then {
-        $0.titleLabel.text = "카테고리"
+        $0.titleLabel.text = Constant.categoryHashtagListViewTitle
         $0.snp.makeConstraints {
             $0.height.equalTo(Constant.hashtagViewHeight)
         }
@@ -74,9 +78,9 @@ final class ProfileViewController: ViewController {
         }
     }
     
-    private let marginView = UIView().then {
+    private let bottomMarginView = UIView().then {
         $0.snp.makeConstraints {
-            $0.height.equalTo(200.0)
+            $0.height.equalTo(Constant.bottomMarginViewHeight)
         }
     }
     
@@ -173,47 +177,9 @@ final class ProfileViewController: ViewController {
     }
     
     private func bindHashtags(output: ProfileViewModel.Output) {
-        output.languages
-            .asDriver(onErrorJustReturn: [])
-            .drive(languageListView.hashtagCollectionView.rx.items) { collectionView, index, language in
-                guard let cell = collectionView.dequeueReusableCell(
-                    withReuseIdentifier: HashtagBadgeCell.identifier,
-                    for: IndexPath(row: index, section: 0)) as? HashtagBadgeCell else {
-                    return UICollectionViewCell()
-                }
-                let hashtag = Languages.idToHashtag(id: language)
-                cell.setHashtag(hashtag: hashtag)
-                return cell
-            }
-            .disposed(by: disposeBag)
-        
-        output.careers
-            .asDriver(onErrorJustReturn: [])
-            .drive(careerListView.hashtagCollectionView.rx.items) { collectionView, index, career in
-                guard let cell = collectionView.dequeueReusableCell(
-                    withReuseIdentifier: HashtagBadgeCell.identifier,
-                    for: IndexPath(row: index, section: 0)) as? HashtagBadgeCell else {
-                    return UICollectionViewCell()
-                }
-                let hashtag = Career.idToHashtag(id: career)
-                cell.setHashtag(hashtag: hashtag)
-                return cell
-            }
-            .disposed(by: disposeBag)
-        
-        output.categorys
-            .asDriver(onErrorJustReturn: [])
-            .drive(categoryListView.hashtagCollectionView.rx.items) { collectionView, index, category in
-                guard let cell = collectionView.dequeueReusableCell(
-                    withReuseIdentifier: HashtagBadgeCell.identifier,
-                    for: IndexPath(row: index, section: 0)) as? HashtagBadgeCell else {
-                    return UICollectionViewCell()
-                }
-                let hashtag = Category.idToHashtag(id: category)
-                cell.setHashtag(hashtag: hashtag)
-                return cell
-            }
-            .disposed(by: disposeBag)
+        languageListView.bind(hashtags: output.languages.asDriver(onErrorJustReturn: []))
+        careerListView.bind(hashtags: output.careers.asDriver(onErrorJustReturn: []))
+        categoryListView.bind(hashtags: output.categorys.asDriver(onErrorJustReturn: []))
         
         output.studyRatingList
             .withUnretained(self)

--- a/Mogakco/Sources/Presentation/Profile/ViewModel/EditProfiileViewModel.swift
+++ b/Mogakco/Sources/Presentation/Profile/ViewModel/EditProfiileViewModel.swift
@@ -113,7 +113,7 @@ final class EditProfiileViewModel: ViewModel {
             }
             .withUnretained(self)
             .subscribe(onNext: { viewModel, _ in
-                viewModel.coordinator?.pop(animated: true)
+                viewModel.coordinator?.popTabbar(animated: true)
             })
             .disposed(by: disposeBag)
     

--- a/Mogakco/Sources/Presentation/Profile/ViewModel/ProfileViewModel.swift
+++ b/Mogakco/Sources/Presentation/Profile/ViewModel/ProfileViewModel.swift
@@ -40,9 +40,9 @@ final class ProfileViewModel: ViewModel {
         let representativeLanguageImage: Observable<UIImage>
         let name: Observable<String>
         let introduce: Observable<String>
-        let languages: Observable<[String]>
-        let careers: Observable<[String]>
-        let categorys: Observable<[String]>
+        let languages: Observable<[Hashtag]>
+        let careers: Observable<[Hashtag]>
+        let categorys: Observable<[Hashtag]>
         let studyRatingList: Observable<[(String, Int)]>
     }
 
@@ -93,9 +93,18 @@ final class ProfileViewModel: ViewModel {
                 .compactMap { UIImage(named: $0) },
             name: user.map { $0.name }.asObservable(),
             introduce: user.map { $0.introduce }.asObservable(),
-            languages: user.map { $0.languages }.asObservable(),
-            careers: user.map { $0.careers }.asObservable(),
-            categorys: user.map { $0.categorys }.asObservable(),
+            languages: user
+                .map { $0.languages }
+                .map { $0.compactMap { Languages.idToHashtag(id: $0) } }
+                .asObservable(),
+            careers: user
+                .map { $0.languages }
+                .map { $0.compactMap { Career.idToHashtag(id: $0) } }
+                .asObservable(),
+            categorys: user
+                .map { $0.languages }
+                .map { $0.compactMap { Category.idToHashtag(id: $0) } }
+                .asObservable(),
             studyRatingList: studyRatingList.asObservable()
         )
     }

--- a/Mogakco/Sources/Presentation/Profile/ViewModel/ProfileViewModel.swift
+++ b/Mogakco/Sources/Presentation/Profile/ViewModel/ProfileViewModel.swift
@@ -78,6 +78,10 @@ final class ProfileViewModel: ViewModel {
                     return viewModel.userUseCase.user(id: user.id)
                 }
             }
+        let studyRatingList = user
+            .map { $0.studyIDs }
+            .withUnretained(self)
+            .flatMap { $0.0.userUseCase.studyRatingList(studyIDs: $0.1) }
 
         return Output(
             isMyProfile: isMyProfile.asObservable(),
@@ -92,7 +96,7 @@ final class ProfileViewModel: ViewModel {
             languages: user.map { $0.languages }.asObservable(),
             careers: user.map { $0.careers }.asObservable(),
             categorys: user.map { $0.categorys }.asObservable(),
-            studyRatingList: userUseCase.myStudyRatingList().asObservable()
+            studyRatingList: studyRatingList.asObservable()
         )
     }
     

--- a/Mogakco/Sources/Util/Constant/Layout.swift
+++ b/Mogakco/Sources/Util/Constant/Layout.swift
@@ -13,4 +13,5 @@ enum Layout {
     static let textFieldHeight: CGFloat = 56
     static let textViewHeight: CGFloat = 56
     static let buttonBottomInset: CGFloat = 16
+    static let tapbarHeaderViewHeight: CGFloat = 68
 }


### PR DESCRIPTION
### PR Type

- [x]  기능 추가 🔨
- [ ]  버그 수정 🐞
- [ ]  리팩토링 🚧
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [ ]  테스트 🔍
 

### Related Issue(작업 내용)

- resolves #232 
    - 프로필 화면의 해시태그, 스터디 목록이 없을 시 대응 UI를 표시합니다.
- resolves #253
  - 프로필 편집 완료 시 pop되지 않는 오류를 수정하였습니다.

### Screenshots(Optional)
<img src="https://user-images.githubusercontent.com/73675540/204243447-c38ced76-ae71-4d89-a8bd-94bf188c9890.png" width="50%">
