### PR TITLE
스터디 목록 새로고침(위로 당길때)

### DIFF
--- a/Mogakco/Sources/Presentation/Study/ViewController/StudyListViewController.swift
+++ b/Mogakco/Sources/Presentation/Study/ViewController/StudyListViewController.swift
@@ -81,8 +81,8 @@ final class StudyListViewController: ViewController {
             }
             .disposed(by: disposeBag)
         
-        output.studyList
-            .subscribe(onNext: { [weak self] _ in
+        output.refreshFinished
+            .subscribe(onNext: { [weak self] in
                 self?.refreshControl.endRefreshing()
             })
             .disposed(by: disposeBag)

--- a/Mogakco/Sources/Presentation/Study/ViewController/StudyListViewController.swift
+++ b/Mogakco/Sources/Presentation/Study/ViewController/StudyListViewController.swift
@@ -17,15 +17,21 @@ final class StudyListViewController: ViewController {
     
     private let header = StudyListHeader()
     
+    private lazy var refreshControl = UIRefreshControl().then {
+        $0.addTarget(self, action: #selector(refreshCollection), for: .valueChanged)
+    }
+    
     private lazy var collectionView = UICollectionView(
         frame: .zero,
         collectionViewLayout: collectionViewLayout()
     ).then {
+        $0.refreshControl = refreshControl
         $0.showsVerticalScrollIndicator = false
         $0.showsHorizontalScrollIndicator = false
         $0.showsVerticalScrollIndicator = false
         $0.register(StudyCell.self, forCellWithReuseIdentifier: StudyCell.identifier)
     }
+    
     
     private let viewModel: StudyListViewModel
 //    private let viewWillAppear = PublishSubject<Void>()
@@ -109,6 +115,13 @@ final class StudyListViewController: ViewController {
             section.interGroupSpacing = 16
             section.contentInsets = .init(top: 1, leading: 16, bottom: 16, trailing: 16)
             return section
+        }
+    }
+    
+    @objc private func refreshCollection() {
+        print("새로고침")
+        DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(3)) { [weak self] in
+            self?.refreshControl.endRefreshing()
         }
     }
 }

--- a/Mogakco/Sources/Presentation/Study/ViewModel/StudyListViewModel.swift
+++ b/Mogakco/Sources/Presentation/Study/ViewModel/StudyListViewModel.swift
@@ -17,6 +17,7 @@ final class StudyListViewModel: ViewModel {
         let viewWillAppear: Observable<Void>
         let plusButtonTapped: Observable<Void>
         let cellSelected: Observable<IndexPath>
+        let refresh: Observable<Void>
     }
     
     struct Output {
@@ -66,6 +67,14 @@ final class StudyListViewModel: ViewModel {
             }
             .disposed(by: disposeBag)
  
-        return Output(studyList: studyList)
+        input.refresh
+            .withUnretained(self)
+            .flatMap { $0.0.useCase.list(sort: .latest, filters: []) }
+            .bind(to: studyList)
+            .disposed(by: disposeBag)
+        
+        return Output(
+            studyList: studyList
+        )
     }
 }


### PR DESCRIPTION
### PR Type

- [x]  기능 추가 🔨
- [ ]  버그 수정 🐞
- [ ]  리팩토링 🚧
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [ ]  테스트 🔍
 

### Related Issue(작업 내용)

- close #49 
    - 스터디 목록을 위로 당기면 새로고침이 시작되고 끝나면 refreshControl이 사라짐

### 참고 사항
- 새로고침 로직을  viewModel의 Strudy publishSubject에 바인딩했는데 bind에서 다음과 같이 바딘딩 되었습니다. 원래 collectionView와 합치려다가 하나로 들어가지 못해 나눴는데 더 좋은 방법이 있을까요?
``` swift
output.studyList
            .bind(to: self.collectionView.rx.items(
                cellIdentifier: StudyCell.identifier,
                cellType: StudyCell.self
            )) { _, study, cell in
                cell.setup(study)
            }
            .disposed(by: disposeBag)
        
output.studyList
    .subscribe(onNext: { [weak self] _ in
        self?.refreshControl.endRefreshing()
    })
    .disposed(by: disposeBag)
```

### Screenshots(Optional)
<img src="https://user-images.githubusercontent.com/86254784/204257083-dc2c7bbd-d6cd-4740-aa91-d2a523595f69.mp4" width="50%">



