### PR TITLE
스터디 나가기 구현 및 나가기 버튼 바인딩

### DIFF
--- a/Mogakco/Sources/Data/DataSources/Protocol/ChatRoomDataSourceProtocol.swift
+++ b/Mogakco/Sources/Data/DataSources/Protocol/ChatRoomDataSourceProtocol.swift
@@ -12,7 +12,6 @@ protocol ChatRoomDataSourceProtocol {
     func list() -> Observable<Documents<[ChatRoomResponseDTO]>>
     func detail(id: String) -> Observable<ChatRoomResponseDTO>
     func chats(id: String) -> Observable<Documents<[ChatResponseDTO]>>
-    func detail(id: String) -> Observable<ChatRoomResponseDTO>
     func create(request: CreateChatRoomRequestDTO) -> Observable<ChatRoomResponseDTO>
     func updateIDs(id: String, request: UpdateUserIDsRequestDTO) -> Observable<ChatRoomResponseDTO>
 }

--- a/Mogakco/Sources/Data/DataSources/Protocol/ChatRoomDataSourceProtocol.swift
+++ b/Mogakco/Sources/Data/DataSources/Protocol/ChatRoomDataSourceProtocol.swift
@@ -12,6 +12,7 @@ protocol ChatRoomDataSourceProtocol {
     func list() -> Observable<Documents<[ChatRoomResponseDTO]>>
     func detail(id: String) -> Observable<ChatRoomResponseDTO>
     func chats(id: String) -> Observable<Documents<[ChatResponseDTO]>>
+    func detail(id: String) -> Observable<ChatRoomResponseDTO>
     func create(request: CreateChatRoomRequestDTO) -> Observable<ChatRoomResponseDTO>
     func updateIDs(id: String, request: UpdateUserIDsRequestDTO) -> Observable<ChatRoomResponseDTO>
 }

--- a/Mogakco/Sources/Data/DataSources/Remote/ChatRoomDataSource.swift
+++ b/Mogakco/Sources/Data/DataSources/Remote/ChatRoomDataSource.swift
@@ -29,6 +29,10 @@ struct ChatRoomDataSource: ChatRoomDataSourceProtocol {
             .catchAndReturn(Documents<[ChatResponseDTO]>(documents: []))
     }
     
+    func detail(id: String) -> Observable<ChatRoomResponseDTO> {
+        return provider.request(ChatRoomTarget.detail(id))
+    }
+    
     func create(request: CreateChatRoomRequestDTO) -> Observable<ChatRoomResponseDTO> {
         return provider.request(ChatRoomTarget.create(request))
     }
@@ -42,6 +46,7 @@ enum ChatRoomTarget {
     case list
     case detail(String)
     case chats(String)
+    case detail(String)
     case create(CreateChatRoomRequestDTO)
     case updateIDs(String, UpdateUserIDsRequestDTO)
 }
@@ -76,6 +81,8 @@ extension ChatRoomTarget: TargetType {
             return "/\(id)"
         case let .chats(id):
             return "/\(id)/chats"
+        case let .detail(id):
+            return "/\(id)"
         case let .create(request):
             return "/?documentId=\(request.id.value)"
         case .updateIDs(let id, _):

--- a/Mogakco/Sources/Data/DataSources/Remote/ChatRoomDataSource.swift
+++ b/Mogakco/Sources/Data/DataSources/Remote/ChatRoomDataSource.swift
@@ -29,10 +29,6 @@ struct ChatRoomDataSource: ChatRoomDataSourceProtocol {
             .catchAndReturn(Documents<[ChatResponseDTO]>(documents: []))
     }
     
-    func detail(id: String) -> Observable<ChatRoomResponseDTO> {
-        return provider.request(ChatRoomTarget.detail(id))
-    }
-    
     func create(request: CreateChatRoomRequestDTO) -> Observable<ChatRoomResponseDTO> {
         return provider.request(ChatRoomTarget.create(request))
     }
@@ -46,7 +42,6 @@ enum ChatRoomTarget {
     case list
     case detail(String)
     case chats(String)
-    case detail(String)
     case create(CreateChatRoomRequestDTO)
     case updateIDs(String, UpdateUserIDsRequestDTO)
 }
@@ -77,8 +72,6 @@ extension ChatRoomTarget: TargetType {
         switch self {
         case .list:
             return ""
-        case .detail(let id):
-            return "/\(id)"
         case let .chats(id):
             return "/\(id)/chats"
         case let .detail(id):

--- a/Mogakco/Sources/Domain/Repositories/StudyRepositoryProtocol.swift
+++ b/Mogakco/Sources/Domain/Repositories/StudyRepositoryProtocol.swift
@@ -15,4 +15,5 @@ protocol StudyRepositoryProtocol {
     func create(study: Study) -> Observable<Study>
     func updateIDs(id: String, userIDs: [String]) -> Observable<Study>
     func join(id: String) -> Observable<Void>
+    func leaveStudy(id: String) -> Observable<Void>
 }

--- a/Mogakco/Sources/Domain/UseCases/LeaveStudyUseCase.swift
+++ b/Mogakco/Sources/Domain/UseCases/LeaveStudyUseCase.swift
@@ -1,0 +1,30 @@
+//
+//  LeaveStudyUseCase.swift
+//  Mogakco
+//
+//  Created by 이주훈 on 2022/11/29.
+//  Copyright © 2022 Mogakco. All rights reserved.
+//
+
+import Foundation
+
+import RxSwift
+
+struct LeaveStudyUseCase: LeaveStudyUseCaseProtocol {
+    let userRepository: UserRepositoryProtocol
+    let studyRepository: StudyRepositoryProtocol
+    let chatRoomRepository: ChatRoomRepositoryProtocol
+    
+    func leaveStudy(id: String) -> Observable<Void> {
+        return Observable.create { emitter in
+            
+            // 1. User에서 정보 삭제
+            
+            // 2. Study에서 정보 삭제
+            
+            // 3. ChatRoom에서 정보 삭제
+            
+            return Disposables.create()
+        }
+    }
+}

--- a/Mogakco/Sources/Domain/UseCases/LeaveStudyUseCase.swift
+++ b/Mogakco/Sources/Domain/UseCases/LeaveStudyUseCase.swift
@@ -17,6 +17,16 @@ struct LeaveStudyUseCase: LeaveStudyUseCaseProtocol {
     
     var disposeBag = DisposeBag()
     
+    init(
+        userRepository: UserRepositoryProtocol,
+        studyRepository: StudyRepositoryProtocol,
+        chatRoomRepository: ChatRoomRepositoryProtocol
+    ) {
+        self.userRepository = userRepository
+        self.studyRepository = studyRepository
+        self.chatRoomRepository = chatRoomRepository
+    }
+    
     func leaveStudy(id: String) -> Observable<Void> {
         return Observable.create { emitter in
             

--- a/Mogakco/Sources/Domain/UseCases/LeaveStudyUseCase.swift
+++ b/Mogakco/Sources/Domain/UseCases/LeaveStudyUseCase.swift
@@ -18,11 +18,44 @@ struct LeaveStudyUseCase: LeaveStudyUseCaseProtocol {
     func leaveStudy(id: String) -> Observable<Void> {
         return Observable.create { emitter in
             
+            // 0. User 정보 업데이트 받기
+            let userInfo = userRepository
+                .load()
+                .flatMap { userRepository.user(id: $0.id) }
+            
             // 1. User에서 정보 삭제
+            let updateUser = userInfo
+                .flatMap {
+                    userRepository.updateIDs(
+                        id: $0.id,
+                        chatRoomIDs: $0.chatRoomIDs.filter { $0 != id },
+                        studyIDs: $0.studyIDs.filter { $0 != id }
+                    )
+                }
+                .flatMap {
+                    userRepository.save(user: $0)
+                }
             
             // 2. Study에서 정보 삭제
+            let updateStudy = Observable
+                .zip(
+                    userInfo,
+                    studyRepository.detail(id: id)
+                )
+                .flatMap { user, study in
+                    studyRepository.updateIDs(
+                        id: study.id,
+                        userIDs: study.userIDs.filter { $0 != user.id }
+                    )
+                }
             
             // 3. ChatRoom에서 정보 삭제
+//            let updateChatRoom = Observable
+//                .zip(
+//                    userInfo,
+//                    chatRoomRepository.
+//                )
+            
             
             return Disposables.create()
         }

--- a/Mogakco/Sources/Domain/UseCases/LeaveStudyUseCase.swift
+++ b/Mogakco/Sources/Domain/UseCases/LeaveStudyUseCase.swift
@@ -30,6 +30,13 @@ struct LeaveStudyUseCase: LeaveStudyUseCaseProtocol {
     func leaveStudy(id: String) -> Observable<Void> {
         return Observable.create { emitter in
             
+            userRepository
+                .load()
+                .subscribe {
+                    print("유저정보: \($0)")
+                }
+                .disposed(by: disposeBag)
+            
             // 0. User 정보 업데이트 받기
             let userInfo = userRepository
                 .load()

--- a/Mogakco/Sources/Domain/UseCases/Protocol/LeaveStudyUseCaseProtocol.swift
+++ b/Mogakco/Sources/Domain/UseCases/Protocol/LeaveStudyUseCaseProtocol.swift
@@ -1,0 +1,15 @@
+//
+//  LeaveStudyUseCaseProtocol.swift
+//  Mogakco
+//
+//  Created by 이주훈 on 2022/11/29.
+//  Copyright © 2022 Mogakco. All rights reserved.
+//
+
+import Foundation
+
+import RxSwift
+
+protocol LeaveStudyUseCaseProtocol {
+    func leaveStudy(id: String) -> Observable<Void>
+}

--- a/Mogakco/Sources/Presentation/Chat/ViewController/ChatViewController.swift
+++ b/Mogakco/Sources/Presentation/Chat/ViewController/ChatViewController.swift
@@ -61,7 +61,6 @@ final class ChatViewController: ViewController {
     }
     
     lazy var blackScreen = UIView(frame: self.view.bounds)
-    
     private let viewModel: ChatViewModel
     
     init(viewModel: ChatViewModel) {

--- a/Mogakco/Sources/Presentation/Chat/ViewModel/ChatViewModel.swift
+++ b/Mogakco/Sources/Presentation/Chat/ViewModel/ChatViewModel.swift
@@ -54,7 +54,10 @@ final class ChatViewModel: ViewModel {
         let inputViewText = PublishSubject<String>()
         let sendMessage = PublishSubject<Void>()
         let messages = PublishSubject<[Chat]>()
-
+        let studyInfoTap = PublishSubject<Void>()
+        let exitStudyTap = PublishSubject<Void>()
+        let showMemberTap = PublishSubject<Void>()
+        
         chatUseCase.fetch(chatRoomID: self.chatRoomID)
             .withUnretained(self)
             .subscribe { _, chat in
@@ -74,10 +77,6 @@ final class ChatViewModel: ViewModel {
             })
             .disposed(by: disposeBag)
         
-        let studyInfoTap = PublishSubject<Void>()
-        let exitStudyTap = PublishSubject<Void>()
-        let showMemberTap = PublishSubject<Void>()
-        
         input.selectedSidebar
             .map { ChatSidebarMenu(row: $0.row) }
             .subscribe { row in
@@ -95,13 +94,11 @@ final class ChatViewModel: ViewModel {
             .subscribe {
                 selectedSidebar.onNext(.exitStudy)
             } onError: { error in
+                print(self.chatRoomID)
                 print(error)
             }
             .disposed(by: disposeBag)
-
         // TODO: 위와 같은 방식으로 studyInfo, showMember추가
-        
-        
         input.sendButtonDidTap
             .withLatestFrom(Observable.combineLatest(
                 chatUseCase.myProfile(),
@@ -121,9 +118,7 @@ final class ChatViewModel: ViewModel {
                         ),
                         to: self.chatRoomID
                     )
-                    .subscribe {
-                        sendMessage.onNext(())
-                    }
+                    .subscribe { sendMessage.onNext(()) }
                     .disposed(by: self.disposeBag)
             }
             .disposed(by: disposeBag)

--- a/Mogakco/Sources/Presentation/Chat/ViewModel/ChatViewModel.swift
+++ b/Mogakco/Sources/Presentation/Chat/ViewModel/ChatViewModel.swift
@@ -31,6 +31,7 @@ final class ChatViewModel: ViewModel {
     
     
     private let chatUseCase: ChatUseCaseProtocol
+    private let leaveStudyUseCase: LeaveStudyUseCaseProtocol
     weak var coordinator: Coordinator?
     var disposeBag = DisposeBag()
     let chatRoomID: String
@@ -38,10 +39,12 @@ final class ChatViewModel: ViewModel {
     init(
         coordinator: Coordinator,
         chatUseCase: ChatUseCaseProtocol,
+        leaveStudyUseCase: LeaveStudyUseCaseProtocol,
         chatRoomID: String
     ) {
         self.coordinator = coordinator
         self.chatUseCase = chatUseCase
+        self.leaveStudyUseCase = leaveStudyUseCase
         self.chatRoomID = chatRoomID
     }
     

--- a/Mogakco/Sources/Presentation/Common/Coordinator/ChatTabCoordinator.swift
+++ b/Mogakco/Sources/Presentation/Common/Coordinator/ChatTabCoordinator.swift
@@ -66,9 +66,7 @@ final class ChatTabCoordinator: Coordinator, ChatTabCoordinatorProtocol {
             userRepository: userRepository
         )
         let leaveStudyUseCase = LeaveStudyUseCase(
-            userRepository: userRepository,
-            studyRepository: studyRepository,
-            chatRoomRepository: chatRoomRespository
+            studyRepository: studyRepository
         )
         
         let viewModel = ChatViewModel(

--- a/Mogakco/Sources/Presentation/Common/Coordinator/ChatTabCoordinator.swift
+++ b/Mogakco/Sources/Presentation/Common/Coordinator/ChatTabCoordinator.swift
@@ -42,10 +42,22 @@ final class ChatTabCoordinator: Coordinator, ChatTabCoordinatorProtocol {
         let localUserDataSource = UserDefaultsUserDataSource()
         let remoteUserDataSource = RemoteUserDataSource(provider: Provider.default)
         let chatDataSource = ChatDataSource()
+        let studyDataSource = StudyDataSource(provider: Provider.default)
+        let chatRoomDataSource = ChatRoomDataSource(provider: Provider.default)
         
         let chatRepository = ChatRepository(chatDataSource: chatDataSource)
         let userRepository = UserRepository(
             localUserDataSource: localUserDataSource,
+            remoteUserDataSource: remoteUserDataSource
+        )
+        let studyRepository = StudyRepository(
+            studyDataSource: studyDataSource,
+            localUserDataSource: localUserDataSource,
+            remoteUserDataSource: remoteUserDataSource,
+            chatRoomDataSource: chatRoomDataSource
+        )
+        let chatRoomRespository = ChatRoomRepository(
+            chatRoomDataSource: chatRoomDataSource,
             remoteUserDataSource: remoteUserDataSource
         )
         
@@ -53,9 +65,16 @@ final class ChatTabCoordinator: Coordinator, ChatTabCoordinatorProtocol {
             chatRepository: chatRepository,
             userRepository: userRepository
         )
+        let leaveStudyUseCase = LeaveStudyUseCase(
+            userRepository: userRepository,
+            studyRepository: studyRepository,
+            chatRoomRepository: chatRoomRespository
+        )
+        
         let viewModel = ChatViewModel(
             coordinator: self,
             chatUseCase: chatUseCase,
+            leaveStudyUseCase: leaveStudyUseCase,
             chatRoomID: chatRoomID
         )
         let chatViewController = ChatViewController(viewModel: viewModel)

--- a/Mogakco/Sources/Presentation/Common/Coordinator/StudyTabCoordinator.swift
+++ b/Mogakco/Sources/Presentation/Common/Coordinator/StudyTabCoordinator.swift
@@ -96,10 +96,22 @@ final class StudyTabCoordinator: Coordinator, StudyTabCoordinatorProtocol {
         let localUserDataSource = UserDefaultsUserDataSource()
         let remoteUserDataSource = RemoteUserDataSource(provider: Provider.default)
         let chatDataSource = ChatDataSource()
+        let studyDataSource = StudyDataSource(provider: Provider.default)
+        let chatRoomDataSource = ChatRoomDataSource(provider: Provider.default)
         
         let chatRepository = ChatRepository(chatDataSource: chatDataSource)
         let userRepository = UserRepository(
             localUserDataSource: localUserDataSource,
+            remoteUserDataSource: remoteUserDataSource
+        )
+        let studyRepository = StudyRepository(
+            studyDataSource: studyDataSource,
+            localUserDataSource: localUserDataSource,
+            remoteUserDataSource: remoteUserDataSource,
+            chatRoomDataSource: chatRoomDataSource
+        )
+        let chatRoomRespository = ChatRoomRepository(
+            chatRoomDataSource: chatRoomDataSource,
             remoteUserDataSource: remoteUserDataSource
         )
         
@@ -107,9 +119,16 @@ final class StudyTabCoordinator: Coordinator, StudyTabCoordinatorProtocol {
             chatRepository: chatRepository,
             userRepository: userRepository
         )
+        let leaveStudyUseCase = LeaveStudyUseCase(
+            userRepository: userRepository,
+            studyRepository: studyRepository,
+            chatRoomRepository: chatRoomRespository
+        )
+        
         let viewModel = ChatViewModel(
             coordinator: self,
             chatUseCase: chatUseCase,
+            leaveStudyUseCase: leaveStudyUseCase,
             chatRoomID: chatRoomID
         )
         let chatViewController = ChatViewController(viewModel: viewModel)

--- a/Mogakco/Sources/Presentation/Common/Coordinator/StudyTabCoordinator.swift
+++ b/Mogakco/Sources/Presentation/Common/Coordinator/StudyTabCoordinator.swift
@@ -120,9 +120,7 @@ final class StudyTabCoordinator: Coordinator, StudyTabCoordinatorProtocol {
             userRepository: userRepository
         )
         let leaveStudyUseCase = LeaveStudyUseCase(
-            userRepository: userRepository,
-            studyRepository: studyRepository,
-            chatRoomRepository: chatRoomRespository
+            studyRepository: studyRepository
         )
         
         let viewModel = ChatViewModel(

--- a/Mogakco/Sources/Presentation/Common/ViewModel/ViewController/ViewController.swift
+++ b/Mogakco/Sources/Presentation/Common/ViewModel/ViewController/ViewController.swift
@@ -11,7 +11,7 @@ import RxSwift
 
 class ViewController: UIViewController {
     
-    let disposeBag = DisposeBag()
+    var disposeBag = DisposeBag()
 
     override func viewDidLoad() {
         super.viewDidLoad()


### PR DESCRIPTION
### PR Type

- [x]  기능 추가 🔨
- [ ]  버그 수정 🐞
- [ ]  리팩토링 🚧
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [ ]  테스트 🔍
 

### Related Issue(작업 내용)

- close #51 
    - UseCase와 Repository를 만들고 채팅방 사이드바에 바인딩
- close #155 
    - 나가기 API 구현(대부분 원래 API를 이용하고 chatRoom detail만 추가했습니다.)

### 참고 사항
- 채팅방을 나가는데 파이어베이스 정보와 달라서 애먹었습니다.(ChatRoom은 있는데 Study가 없는 이슈) 기능도 생긴김에 한 번 데이터를 싹 갈아엎는 것도 괜찮을 것 같습니다.
- chatRoom과 Study ID를 같이 쓰는 이유가 여기있는것 같습니다. 두개로 나뉘면 처리에 불편할 것 같더라구요.
- ~~스터디를 나간 후 채팅목록에 바로 반영되지 않는 [이슈](https://github.com/boostcampwm-2022/iOS04-Mogakco/issues/283#issue-1467546918)가 있습니다.~~
- 일단은 그냥 나가는데 alret를 띄우거나 하는 등의 처리도 고려하면 좋을 것 같습니다.
