### PR TITLE
스터디 생성 모달 구현 및 정렬 필터 ViewModel 내 구현

### DIFF
--- a/Mogakco/Sources/Domain/Entities/StudyFilter.swift
+++ b/Mogakco/Sources/Domain/Entities/StudyFilter.swift
@@ -8,7 +8,16 @@
 
 import Foundation
 
-enum StudyFilter {
+enum StudyFilter: Equatable {
     case languages([String])
     case category(String)
+    
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        switch (lhs, rhs) {
+        case (.languages, .languages), (.category, .category):
+            return true
+        default:
+            return false
+        }
+    }
 }

--- a/Mogakco/Sources/Domain/Entities/StudySort.swift
+++ b/Mogakco/Sources/Domain/Entities/StudySort.swift
@@ -8,6 +8,15 @@
 
 import Foundation
 
-enum StudySort {
+enum StudySort: CaseIterable {
     case latest, oldest
+    
+    var title: String {
+        switch self {
+        case .latest:
+            return "최신순"
+        case .oldest:
+            return "오래된순"
+        }
+    }
 }

--- a/Mogakco/Sources/Presentation/Common/Coordinator/Protocol/StudyTabCoordinatorProtocol.swift
+++ b/Mogakco/Sources/Presentation/Common/Coordinator/Protocol/StudyTabCoordinatorProtocol.swift
@@ -8,6 +8,8 @@
 
 import Foundation
 
+import RxSwift
+
 protocol StudyTabCoordinatorProtocol: AnyObject {
     func showStudyList()
     func showStudyDetail(id: String)
@@ -15,5 +17,6 @@ protocol StudyTabCoordinatorProtocol: AnyObject {
     func showChatDetail(chatRoomID: String)
     func showCategorySelect(delegate: HashtagSelectProtocol?)
     func showLanguageSelect(delegate: HashtagSelectProtocol?)
+    func showSelectStudySort(studySortObserver: AnyObserver<StudySort>)
     func goToPrevScreen()
 }

--- a/Mogakco/Sources/Presentation/Common/Coordinator/StudyTabCoordinator.swift
+++ b/Mogakco/Sources/Presentation/Common/Coordinator/StudyTabCoordinator.swift
@@ -8,6 +8,8 @@
 
 import UIKit
 
+import RxSwift
+
 final class StudyTabCoordinator: Coordinator, StudyTabCoordinatorProtocol {
     
     weak var delegate: CoordinatorFinishDelegate?
@@ -166,6 +168,20 @@ final class StudyTabCoordinator: Coordinator, StudyTabCoordinatorProtocol {
             viewModel: viewModel
         )
         navigationController.tabBarController?.navigationController?.pushViewController(viewController, animated: true)
+    }
+    
+    func showSelectStudySort(studySortObserver: AnyObserver<StudySort>) {
+        let viewModel = SelectStudySortViewModel(studySortObserver: studySortObserver, coordinator: self)
+        let viewController = SelectStudySortViewController(viewModel: viewModel)
+        viewController.modalPresentationStyle = .pageSheet
+        guard let sheet = viewController.sheetPresentationController else { return }
+        sheet.detents = [
+            .custom(resolver: { _ in
+                return 130.0
+            })
+        ]
+        sheet.prefersGrabberVisible = true
+        navigationController.tabBarController?.present(viewController, animated: true)
     }
     
     func goToPrevScreen() {

--- a/Mogakco/Sources/Presentation/Common/Coordinator/StudyTabCoordinator.swift
+++ b/Mogakco/Sources/Presentation/Common/Coordinator/StudyTabCoordinator.swift
@@ -28,7 +28,7 @@ final class StudyTabCoordinator: Coordinator, StudyTabCoordinatorProtocol {
         let viewController = StudyListViewController(
             viewModel: StudyListViewModel(
                 coordinator: self,
-                useCase: StudyListUseCase(
+                studyListUseCase: StudyListUseCase(
                     repository: StudyRepository(
                         studyDataSource: StudyDataSource(provider: Provider.default),
                         localUserDataSource: UserDefaultsUserDataSource(),

--- a/Mogakco/Sources/Presentation/Study/View/StudyListHeader.swift
+++ b/Mogakco/Sources/Presentation/Study/View/StudyListHeader.swift
@@ -84,7 +84,6 @@ final class StudyListHeader: UIView {
     override init(frame: CGRect) {
         super.init(frame: frame)
         layout()
-        bind()
     }
     
     required init?(coder: NSCoder) {
@@ -113,52 +112,10 @@ final class StudyListHeader: UIView {
             make.top.equalTo(topStackView.snp.bottom).offset(10)
         }
     }
-    
-    private func bind() {
-        
-        sortButton.rx.tap
-            .compactMap({ [weak self] in
-                self?.sortButton.isSelected.toggle()
-                let isSelected = self?.sortButton.isSelected
-                return self?.borderColor(isSelected: isSelected ?? false)
-            })
-            .subscribe { [weak self] in
-                self?.sortButton.layer.borderColor = $0.cgColor
-            }
-            .disposed(by: disposeBag)
-        
-        languageButton.rx.tap
-            .compactMap({ [weak self] in
-                self?.languageButton.isSelected.toggle()
-                let isSelected = self?.languageButton.isSelected
-                return self?.borderColor(isSelected: isSelected ?? false)
-            })
-            .subscribe { [weak self] in
-                self?.languageButton.layer.borderColor = $0.cgColor
-            }
-            .disposed(by: disposeBag)
-        
-        categoryButton.rx.tap
-            .compactMap({ [weak self] in
-                self?.categoryButton.isSelected.toggle()
-                let isSelected = self?.categoryButton.isSelected
-                return self?.borderColor(isSelected: isSelected ?? false)
-            })
-            .subscribe { [weak self] in
-                self?.categoryButton.layer.borderColor = $0.cgColor
-            }
-            .disposed(by: disposeBag)
-        
-        resetButton.rx.tap
-            .compactMap({ [weak self] in
-                self?.resetButton.isSelected.toggle()
-                let isSelected = self?.resetButton.isSelected
-                return self?.borderColor(isSelected: isSelected ?? false)
-            })
-            .subscribe { [weak self] in
-                self?.resetButton.layer.borderColor = $0.cgColor
-            }
-            .disposed(by: disposeBag)
+   
+    func attributeButtonBorderColor(button: UIButton?) {
+        guard let button = button else { return }
+        button.layer.borderColor = borderColor(isSelected: button.isSelected).cgColor
     }
     
     private static func configuration(title: String) -> UIButton.Configuration {

--- a/Mogakco/Sources/Presentation/Study/View/StudySortCell.swift
+++ b/Mogakco/Sources/Presentation/Study/View/StudySortCell.swift
@@ -1,0 +1,51 @@
+//
+//  StudySortCell.swift
+//  Mogakco
+//
+//  Created by 김범수 on 2022/11/29.
+//  Copyright © 2022 Mogakco. All rights reserved.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class StudySortCell: UICollectionViewCell, Identifiable {
+    
+    private let titleLabel = UILabel().then {
+        $0.font = UIFont(name: SFPro.regular.rawValue, size: 13)
+        $0.textColor = .mogakcoColor.typographyPrimary
+        $0.textAlignment = .center
+    }
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        layout()
+        attribute()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Methods
+    
+    func configure(studySort: StudySort) {
+        titleLabel.text = studySort.title
+    }
+    
+    private func layout() {
+        addSubview(titleLabel)
+        titleLabel.snp.makeConstraints {
+            $0.edges.equalToSuperview().inset(8.0)
+        }
+    }
+    
+    private func attribute() {
+        addShadow(offset: .init(width: 2.0, height: 2.0))
+        layer.borderWidth = 1.0
+        layer.borderColor = UIColor.mogakcoColor.borderDefault?.cgColor
+        layer.cornerRadius = 8.0
+    }
+}

--- a/Mogakco/Sources/Presentation/Study/ViewController/SelectStudySortViewController.swift
+++ b/Mogakco/Sources/Presentation/Study/ViewController/SelectStudySortViewController.swift
@@ -1,0 +1,95 @@
+//
+//  SelectStudySortViewController.swift
+//  Mogakco
+//
+//  Created by 김범수 on 2022/11/29.
+//  Copyright © 2022 Mogakco. All rights reserved.
+//
+
+import UIKit
+
+import RxCocoa
+import RxSwift
+
+final class SelectStudySortViewController: ViewController {
+    
+    enum Constant {
+        static let cellHeight = 40.0
+    }
+    
+    private let titleLabel = UILabel().then {
+        $0.font = UIFont.mogakcoFont.mediumBold
+        $0.text = "정렬"
+        $0.textAlignment = .center
+    }
+    
+    private let sortCollectionView = UICollectionView(
+        frame: .zero,
+        collectionViewLayout: UICollectionViewFlowLayout()).then {
+            let layout = UICollectionViewFlowLayout()
+            layout.estimatedItemSize = UICollectionViewFlowLayout.automaticSize
+            layout.itemSize = CGSize(width: 60.0, height: Constant.cellHeight)
+            layout.sectionInset = UIEdgeInsets(top: 0.0, left: 8.0, bottom: 0.0, right: 8.0)
+            $0.collectionViewLayout = layout
+            $0.register(StudySortCell.self, forCellWithReuseIdentifier: StudySortCell.identifier)
+            $0.showsHorizontalScrollIndicator = false
+            $0.bounces = false
+            layout.scrollDirection = .horizontal
+            $0.isPagingEnabled = false
+        }
+    
+    private let bag = DisposeBag()
+    private let viewModel: SelectStudySortViewModel
+    
+    // MARK: - Inits
+    
+    init(viewModel: SelectStudySortViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func bind() {
+        let input = SelectStudySortViewModel.Input(
+            selectedStudySort: sortCollectionView.rx.modelSelected(StudySort.self).asObservable()
+        )
+        
+        let output = viewModel.transform(input: input)
+        
+        output.studySorts
+        
+            .drive(sortCollectionView.rx.items) { collectionView, index, studySort in
+                guard let cell = collectionView.dequeueReusableCell(
+                    withReuseIdentifier: StudySortCell.identifier,
+                    for: IndexPath(row: index, section: 0)) as? StudySortCell else {
+                        return UICollectionViewCell()
+                    }
+                cell.configure(studySort: studySort)
+                return cell
+            }
+            .disposed(by: disposeBag)
+    }
+    
+    override func layout() {
+        layoutTitleLabel()
+        layoutSortCollectionView()
+    }
+    
+    private func layoutTitleLabel() {
+        view.addSubview(titleLabel)
+        titleLabel.snp.makeConstraints {
+            $0.leading.trailing.top.equalTo(view.safeAreaLayoutGuide).inset(32.0)
+        }
+    }
+    
+    private func layoutSortCollectionView() {
+        view.addSubview(sortCollectionView)
+        sortCollectionView.snp.makeConstraints {
+            $0.leading.trailing.bottom.equalTo(view.safeAreaLayoutGuide).inset(16.0)
+            $0.height.equalTo(Constant.cellHeight)
+        }
+    }
+}

--- a/Mogakco/Sources/Presentation/Study/ViewController/SelectStudySortViewController.swift
+++ b/Mogakco/Sources/Presentation/Study/ViewController/SelectStudySortViewController.swift
@@ -36,7 +36,7 @@ final class SelectStudySortViewController: ViewController {
             $0.bounces = false
             layout.scrollDirection = .horizontal
             $0.isPagingEnabled = false
-        }
+    }
     
     private let bag = DisposeBag()
     private let viewModel: SelectStudySortViewModel

--- a/Mogakco/Sources/Presentation/Study/ViewController/StudyListViewController.swift
+++ b/Mogakco/Sources/Presentation/Study/ViewController/StudyListViewController.swift
@@ -66,7 +66,11 @@ final class StudyListViewController: ViewController {
             viewWillAppear: self.rx.viewWillAppear.map { _ in () }.asObservable(),
             plusButtonTapped: header.plusButton.rx.tap.asObservable(),
             cellSelected: collectionView.rx.itemSelected.asObservable(),
-            refresh: refreshControl.rx.controlEvent(.valueChanged).asObservable()
+            refresh: refreshControl.rx.controlEvent(.valueChanged).asObservable(),
+            sortButtonTapped: header.sortButton.rx.tap.asObservable(),
+            languageButtonTapped: header.languageButton.rx.tap.asObservable(),
+            categoryButtonTapped: header.categoryButton.rx.tap.asObservable(),
+            resetButtonTapped: header.resetButton.rx.tap.asObservable()
         )
         
         let output = viewModel.transform(input: input)

--- a/Mogakco/Sources/Presentation/Study/ViewController/StudyListViewController.swift
+++ b/Mogakco/Sources/Presentation/Study/ViewController/StudyListViewController.swift
@@ -76,7 +76,7 @@ final class StudyListViewController: ViewController {
         let output = viewModel.transform(input: input)
         
         output.studyList
-            .bind(to: self.collectionView.rx.items(
+            .drive(self.collectionView.rx.items(
                 cellIdentifier: StudyCell.identifier,
                 cellType: StudyCell.self
             )) { _, study, cell in
@@ -85,8 +85,29 @@ final class StudyListViewController: ViewController {
             .disposed(by: disposeBag)
         
         output.refreshFinished
-            .subscribe(onNext: { [weak self] in
+            .emit(onNext: { [weak self] in
                 self?.refreshControl.endRefreshing()
+            })
+            .disposed(by: disposeBag)
+        
+        output.sortSelected
+            .drive(onNext: { [weak self] in
+                self?.header.sortButton.isSelected = $0
+                self?.header.attributeButtonBorderColor(button: self?.header.sortButton)
+            })
+            .disposed(by: disposeBag)
+        
+        output.languageSelected
+            .drive(onNext: { [weak self] in
+                self?.header.languageButton.isSelected = $0
+                self?.header.attributeButtonBorderColor(button: self?.header.languageButton)
+            })
+            .disposed(by: disposeBag)
+        
+        output.categorySelected
+            .drive(onNext: { [weak self] in
+                self?.header.categoryButton.isSelected = $0
+                self?.header.attributeButtonBorderColor(button: self?.header.categoryButton)
             })
             .disposed(by: disposeBag)
     }

--- a/Mogakco/Sources/Presentation/Study/ViewModel/SelectStudySortViewModel.swift
+++ b/Mogakco/Sources/Presentation/Study/ViewModel/SelectStudySortViewModel.swift
@@ -1,0 +1,47 @@
+//
+//  SelectStudySortViewModel.swift
+//  Mogakco
+//
+//  Created by 김범수 on 2022/11/29.
+//  Copyright © 2022 Mogakco. All rights reserved.
+//
+
+import RxCocoa
+import RxSwift
+
+final class SelectStudySortViewModel: ViewModel {
+    
+    struct Input {
+        let selectedStudySort: Observable<StudySort>
+    }
+    
+    struct Output {
+        let studySorts: Driver<[StudySort]>
+    }
+    
+    private weak var coordinator: StudyTabCoordinatorProtocol?
+    private let studySortObserver: AnyObserver<StudySort>
+    var disposeBag = DisposeBag()
+    
+    init(
+        studySortObserver: AnyObserver<StudySort>,
+        coordinator: StudyTabCoordinatorProtocol
+    ) {
+        self.studySortObserver = studySortObserver
+        self.coordinator = coordinator
+    }
+    
+    func transform(input: Input) -> Output {
+        input.selectedStudySort
+            .withUnretained(self)
+            .subscribe(onNext: { viewModel, studySort in
+                viewModel.studySortObserver.onNext(studySort)
+                // TODO: dismiss
+            })
+            .disposed(by: disposeBag)
+        
+        return Output(
+            studySorts: Driver.just(StudySort.allCases)
+        )
+    }
+}


### PR DESCRIPTION
### PR Type

- [x]  기능 추가 🔨
- [ ]  버그 수정 🐞
- [ ]  리팩토링 🚧
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [ ]  테스트 🔍
 

### Related Issue(작업 내용)

- resolves #75, resolves #76
    - 스터디 정렬 바텀 모달 구현
- resolves #39 
    - 스터디 목록 정렬 필터링 구현

### 참고 사항

- 스터디 정렬 바텀 모달에서 정렬 방식 선택 후 dismiss하려하는데 아직 dismiss를 사용하는 방법을 못찾겠는데 아직 없는거겠죠?! @sominn9 

- 스터디 정렬 바텀 모달에 데이터 전달을 delegate 패턴 대신 observer를 이용하여 이벤트를 받아왔습니다 혹시 selecthashtag 부분도 같은 방식으로 처리되는게 좋을지 delegate 그대로 가는게 좋을지 얘기해보면 좋을 것 같아요! @juhoon-lee 

### Screenshots(Optional)
https://user-images.githubusercontent.com/73675540/204536643-b924d6f9-68c9-49d4-9071-58f9ed521772.mp4


