### PR TITLE
onError 핸들링을 위한 Extension 추가

### DIFF
--- a/Mogakco/Sources/Presentation/Login/ViewController/LoginViewController.swift
+++ b/Mogakco/Sources/Presentation/Login/ViewController/LoginViewController.swift
@@ -52,7 +52,11 @@ final class LoginViewController: ViewController {
             loginButtonTap: loginButton.rx.tap.asObservable()
         )
 
-        _ = viewModel.transform(input: input)
+        let output = viewModel.transform(input: input)
+        
+        output.presentError
+            .emit(to: rx.presentAlert)
+            .disposed(by: disposeBag)
     }
     
     override func layout() {

--- a/Mogakco/Sources/Util/Extension/ObservableType+Result.swift
+++ b/Mogakco/Sources/Util/Extension/ObservableType+Result.swift
@@ -1,0 +1,16 @@
+//
+//  ObservableType+Result.swift
+//  Mogakco
+//
+//  Created by 김범수 on 2022/11/30.
+//  Copyright © 2022 Mogakco. All rights reserved.
+//
+
+import RxSwift
+
+extension ObservableType {
+    func asResult() -> Observable<Result<Element, Error>> {
+        return self.map { .success($0) }
+            .catch { .just(.failure($0)) }
+    }
+}

--- a/Mogakco/Sources/Util/Extension/RxUIViewController+Alert.swift
+++ b/Mogakco/Sources/Util/Extension/RxUIViewController+Alert.swift
@@ -1,0 +1,25 @@
+//
+//  RxUIViewController+Alert.swift
+//  Mogakco
+//
+//  Created by 김범수 on 2022/11/30.
+//  Copyright © 2022 Mogakco. All rights reserved.
+//
+
+import UIKit
+
+import RxSwift
+
+extension Reactive where Base: UIViewController {
+    var presentAlert: Binder<String> {
+        return Binder(base) { base, message in
+            let alertController = UIAlertController(title: "문제가 발생했어요", message: message, preferredStyle: .alert)
+
+            let action = UIAlertAction(title: "확인", style: .default, handler: nil)
+
+            alertController.addAction(action)
+
+            base.present(alertController, animated: true, completion: nil)
+        }
+    }
+}


### PR DESCRIPTION
### PR Type

- [x]  기능 추가 🔨
- [ ]  버그 수정 🐞
- [ ]  리팩토링 🚧
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [ ]  테스트 🔍
 

### Related Issue(작업 내용)

- resolve #273 
    - onError 핸들링을 위한 asResult, presentAlert Extension을 추가하였습니다

### 참고 사항
로그인 실패 시 간단한 예외처리 예시 코드를 추가해놔서 확인하시면 좋을 것 같습니다
각자 구현한 API 호출 시에 실패 시 처리를 추가하면 좋을 것 같습니다
에러 메시지는 가공이 필요할 것 같아요

### Screenshots(Optional)
<img src="https://user-images.githubusercontent.com/73675540/204717557-a558d2a5-dd10-4d58-83e8-5f2b05a37645.png" width="50%">
