### PR TITLE
채팅방 페이징 구현

### DIFF
--- a/Mogakco/Sources/Data/DataSources/Protocol/ChatDataSourceProtocol.swift
+++ b/Mogakco/Sources/Data/DataSources/Protocol/ChatDataSourceProtocol.swift
@@ -9,6 +9,8 @@
 import RxSwift
 
 protocol ChatDataSourceProtocol {
-    func fetch(chatRoomID: String) -> Observable<ChatResponseDTO>
-    func send(chat: Chat, to chatRoomID: String) -> Observable<Void> // Void? Error?
+    func fetchAll(chatRoomID: String) -> Observable<ChatResponseDTO>
+    func reload(chatRoomID: String) -> Observable<ChatResponseDTO>
+    func observe(chatRoomID: String) -> Observable<ChatResponseDTO> 
+    func send(chat: Chat, to chatRoomID: String) -> Observable<Void>
 }

--- a/Mogakco/Sources/Data/DataSources/Protocol/ChatDataSourceProtocol.swift
+++ b/Mogakco/Sources/Data/DataSources/Protocol/ChatDataSourceProtocol.swift
@@ -9,8 +9,8 @@
 import RxSwift
 
 protocol ChatDataSourceProtocol {
-    func fetchAll(chatRoomID: String) -> Observable<ChatResponseDTO>
-    func reload(chatRoomID: String) -> Observable<ChatResponseDTO>
+    func fetchAll(chatRoomID: String) -> Observable<[ChatResponseDTO]>
+    func reload(chatRoomID: String) -> Observable<[ChatResponseDTO]>
     func observe(chatRoomID: String) -> Observable<ChatResponseDTO> 
     func send(chat: Chat, to chatRoomID: String) -> Observable<Void>
 }

--- a/Mogakco/Sources/Data/DataSources/Remote/ChatDataSource.swift
+++ b/Mogakco/Sources/Data/DataSources/Remote/ChatDataSource.swift
@@ -9,7 +9,10 @@
 import RxSwift
 import Firebase
 
-struct ChatDataSource: ChatDataSourceProtocol {
+final class ChatDataSource: ChatDataSourceProtocol {
+    
+    var listener: ListenerRegistration?
+    var page: DocumentSnapshot!
     
     enum Collection {
         static let ChatRoom = Firestore.firestore().collection("chatroom")

--- a/Mogakco/Sources/Data/Repositories/ChatRepository.swift
+++ b/Mogakco/Sources/Data/Repositories/ChatRepository.swift
@@ -18,12 +18,12 @@ struct ChatRepository: ChatRepositoryProtocol {
         self.chatDataSource = chatDataSource
     }
 
-    func fetchAll(chatRoomID: String) -> Observable<Chat> {
-        return chatDataSource.fetchAll(chatRoomID: chatRoomID).map { $0.toDomain() }
+    func fetchAll(chatRoomID: String) -> Observable<[Chat]> {
+        return chatDataSource.fetchAll(chatRoomID: chatRoomID).map { $0.map { $0.toDomain() } }
     }
     
-    func reload(chatRoomID: String) -> Observable<Chat> {
-        return chatDataSource.reload(chatRoomID: chatRoomID).map { $0.toDomain() }
+    func reload(chatRoomID: String) -> Observable<[Chat]> {
+        return chatDataSource.reload(chatRoomID: chatRoomID).map { $0.map { $0.toDomain() } }
     }
     
     func observe(chatRoomID: String) -> Observable<Chat> {

--- a/Mogakco/Sources/Data/Repositories/ChatRepository.swift
+++ b/Mogakco/Sources/Data/Repositories/ChatRepository.swift
@@ -18,8 +18,16 @@ struct ChatRepository: ChatRepositoryProtocol {
         self.chatDataSource = chatDataSource
     }
 
-    func fetch(chatRoomID: String) -> Observable<Chat> {
-        return chatDataSource.fetch(chatRoomID: chatRoomID).map { $0.toDomain() }
+    func fetchAll(chatRoomID: String) -> Observable<Chat> {
+        return chatDataSource.fetchAll(chatRoomID: chatRoomID).map { $0.toDomain() }
+    }
+    
+    func reload(chatRoomID: String) -> Observable<Chat> {
+        return chatDataSource.reload(chatRoomID: chatRoomID).map { $0.toDomain() }
+    }
+    
+    func observe(chatRoomID: String) -> Observable<Chat> {
+        return chatDataSource.observe(chatRoomID: chatRoomID).map { $0.toDomain() }
     }
 
     func send(chat: Chat, to chatRoomID: String) -> Observable<Void> {

--- a/Mogakco/Sources/Domain/Repositories/ChatRepositoryProtocol.swift
+++ b/Mogakco/Sources/Domain/Repositories/ChatRepositoryProtocol.swift
@@ -9,8 +9,8 @@
 import RxSwift
 
 protocol ChatRepositoryProtocol {
-    func fetchAll(chatRoomID: String) -> Observable<Chat>
-    func reload(chatRoomID: String) -> Observable<Chat>
+    func fetchAll(chatRoomID: String) -> Observable<[Chat]>
+    func reload(chatRoomID: String) -> Observable<[Chat]>
     func observe(chatRoomID: String) -> Observable<Chat>
     func send(chat: Chat, to chatRoomID: String) -> Observable<Void>
 }

--- a/Mogakco/Sources/Domain/Repositories/ChatRepositoryProtocol.swift
+++ b/Mogakco/Sources/Domain/Repositories/ChatRepositoryProtocol.swift
@@ -9,6 +9,8 @@
 import RxSwift
 
 protocol ChatRepositoryProtocol {
-    func fetch(chatRoomID: String) -> Observable<Chat>
-    func send(chat: Chat, to chatRoomID: String) -> Observable<Void> // Chat으로?
+    func fetchAll(chatRoomID: String) -> Observable<Chat>
+    func reload(chatRoomID: String) -> Observable<Chat>
+    func observe(chatRoomID: String) -> Observable<Chat>
+    func send(chat: Chat, to chatRoomID: String) -> Observable<Void>
 }

--- a/Mogakco/Sources/Domain/UseCases/ChatUseCase.swift
+++ b/Mogakco/Sources/Domain/UseCases/ChatUseCase.swift
@@ -22,9 +22,43 @@ struct ChatUseCase: ChatUseCaseProtocol {
         self.userRepository = userRepository
     }
     
-    func fetch(chatRoomID: String) -> Observable<Chat> {
+    func fetchAll(chatRoomID: String) -> Observable<Chat> {
         return chatRepository
-            .fetch(chatRoomID: chatRoomID)
+            .fetchAll(chatRoomID: chatRoomID)
+            .flatMap {
+                var chat = $0
+                return Observable.combineLatest(
+                    userRepository.user(id: chat.userID),
+                    userRepository.load()
+                )
+                .map { chatUserData, myUserData in
+                    chat.user = chatUserData
+                    chat.isFromCurrentUser = chatUserData.id == myUserData.id
+                    return chat
+                }
+            }
+    }
+    
+    func reload(chatRoomID: String) -> Observable<Chat> {
+        return chatRepository
+            .reload(chatRoomID: chatRoomID)
+            .flatMap {
+                var chat = $0
+                return Observable.combineLatest(
+                    userRepository.user(id: chat.userID),
+                    userRepository.load()
+                )
+                .map { chatUserData, myUserData in
+                    chat.user = chatUserData
+                    chat.isFromCurrentUser = chatUserData.id == myUserData.id
+                    return chat
+                }
+            }
+    }
+    
+    func observe(chatRoomID: String) -> Observable<Chat> {
+        return chatRepository
+            .observe(chatRoomID: chatRoomID)
             .flatMap {
                 var chat = $0
                 return Observable.combineLatest(

--- a/Mogakco/Sources/Domain/UseCases/Protocol/ChatUseCaseProtocol.swift
+++ b/Mogakco/Sources/Domain/UseCases/Protocol/ChatUseCaseProtocol.swift
@@ -9,8 +9,8 @@
 import RxSwift
 
 protocol ChatUseCaseProtocol {
-    func fetchAll(chatRoomID: String) -> Observable<Chat>
-    func reload(chatRoomID: String) -> Observable<Chat>
+    func fetchAll(chatRoomID: String) -> Observable<[Chat]>
+    func reload(chatRoomID: String) -> Observable<[Chat]>
     func observe(chatRoomID: String) -> Observable<Chat>
     func send(chat: Chat, to chatRoomID: String) -> Observable<Void>
     func myProfile() -> Observable<User> 

--- a/Mogakco/Sources/Domain/UseCases/Protocol/ChatUseCaseProtocol.swift
+++ b/Mogakco/Sources/Domain/UseCases/Protocol/ChatUseCaseProtocol.swift
@@ -9,7 +9,9 @@
 import RxSwift
 
 protocol ChatUseCaseProtocol {
-    func fetch(chatRoomID: String) -> Observable<Chat>
+    func fetchAll(chatRoomID: String) -> Observable<Chat>
+    func reload(chatRoomID: String) -> Observable<Chat>
+    func observe(chatRoomID: String) -> Observable<Chat>
     func send(chat: Chat, to chatRoomID: String) -> Observable<Void>
     func myProfile() -> Observable<User> 
 }

--- a/Mogakco/Sources/Presentation/Chat/ViewController/ChatViewController.swift
+++ b/Mogakco/Sources/Presentation/Chat/ViewController/ChatViewController.swift
@@ -37,6 +37,7 @@ final class ChatViewController: ViewController {
             right: 0)
         layout.itemSize = CGSize(width: view.frame.width, height: 60)
         layout.minimumLineSpacing = 8.0
+        $0.refreshControl = UIRefreshControl()
         $0.collectionViewLayout = layout
         $0.register(ChatCell.self, forCellWithReuseIdentifier: ChatCell.identifier)
         $0.alwaysBounceVertical = true
@@ -113,7 +114,8 @@ final class ChatViewController: ViewController {
             studyInfoButtonDidTap: studyInfoButton.rx.tap.asObservable(),
             selectedSidebar: sidebarView.tableView.rx.itemSelected.asObservable(),
             sendButtonDidTap: messageInputView.sendButton.rx.tap.asObservable(),
-            inputViewText: messageInputView.messageInputTextView.rx.text.orEmpty.asObservable()
+            inputViewText: messageInputView.messageInputTextView.rx.text.orEmpty.asObservable(),
+            pagination: collectionView.refreshControl?.rx.controlEvent(.valueChanged).asObservable()
         )
 
         let output = viewModel.transform(input: input)
@@ -160,6 +162,12 @@ final class ChatViewController: ViewController {
                 self.hideSidebarView()
                 self.sidebarMenuDidTap(row: row)
             }
+            .disposed(by: disposeBag)
+        
+        output.refreshFinished
+            .subscribe(onNext: { [weak self] _ in
+                self?.collectionView.refreshControl?.endRefreshing()
+            })
             .disposed(by: disposeBag)
         
         output.sendMessage

--- a/Mogakco/Sources/Presentation/Chat/ViewModel/ChatViewModel.swift
+++ b/Mogakco/Sources/Presentation/Chat/ViewModel/ChatViewModel.swift
@@ -122,7 +122,7 @@ final class ChatViewModel: ViewModel {
                             userID: user.id,
                             message: message,
                             chatRoomID: self.chatRoomID,
-                            date: Date().toInt(dateFormat: "yyyyMMddHHmmss"),
+                            date: Date().toInt(dateFormat: Format.chatDateFormat),
                             readUserIDs: [user.id]
                         ),
                         to: self.chatRoomID

--- a/Mogakco/Sources/Presentation/Chat/ViewModel/ChatViewModel.swift
+++ b/Mogakco/Sources/Presentation/Chat/ViewModel/ChatViewModel.swift
@@ -70,8 +70,8 @@ final class ChatViewModel: ViewModel {
                 self.chatUseCase
                     .reload(chatRoomID: self.chatRoomID)
                     .withLatestFrom(self.messages) { ($0, $1) }
-                    .subscribe(onNext: { orginalChats, newChat in
-                        self.messages.accept([orginalChats] + newChat)
+                    .subscribe(onNext: { newChat, originalChats in
+                        self.messages.accept(newChat + originalChats)
                     })
                     .disposed(by: self.disposeBag)
                 
@@ -148,10 +148,10 @@ final class ChatViewModel: ViewModel {
     private func bindFirebase() {
         chatUseCase.observe(chatRoomID: chatRoomID)
             .withLatestFrom(messages) { ($0, $1) }
-            .subscribe(onNext: { [weak self] originalChats, newChat in
+            .subscribe(onNext: { [weak self] newChat, originalChats in
                 if self?.isFirst == false {
                     print("self?.isFirst : ", newChat, originalChats)
-                    self?.messages.accept(newChat + [originalChats])
+                    self?.messages.accept( originalChats + [newChat])
                 } else {
                     self?.isFirst = false
                 }
@@ -160,8 +160,9 @@ final class ChatViewModel: ViewModel {
         
         chatUseCase.fetchAll(chatRoomID: chatRoomID)
             .withLatestFrom(messages) { ($0, $1) }
-            .subscribe(onNext: { [weak self] originChats, newChat in
-                self?.messages.accept([originChats] + newChat)
+            .subscribe(onNext: { [weak self] newChat, originalChat in
+                
+                self?.messages.accept(newChat + originalChat)
             })
             .disposed(by: disposeBag)
     }

--- a/Mogakco/Sources/Util/Constant/Format.swift
+++ b/Mogakco/Sources/Util/Constant/Format.swift
@@ -9,6 +9,7 @@
 import Foundation
 
 enum Format {
+    static let chatDateFormat: String = "yyyyMMddHHmmss"
     static let compactDateFormat: String = "yyyyMMddHHmm"
     static let detailDateFormat: String = "yyyy년 MM월 dd일 HH시 mm분"
 }


### PR DESCRIPTION
### PR Type

- [x]  기능 추가 🔨
- [ ]  버그 수정 🐞
- [x]  리팩토링 🚧
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [ ]  테스트 🔍
 

### Related Issue(작업 내용)
- close #257 
  - 화면 위로 드래깅 했을 때 리로딩 UI
- close #256 
  - 이전 채팅을 불러올 때 페이지네이션 구현

### 참고 사항
- 저녁에 얘기했던 페이징과 observe 역할을 나누었습니다!
- 처음에 이전 채팅들을 가져오는 fetchAll
- 드래깅 했을 때 채팅을 더 불러오는 reload
- 채팅을 받아오는 observe
- 채팅이 섞이는 이유를 알았습니다! 채팅은 순서대로 오는데 중간에 ChatUseCase에서 Chat 모델 안에 User정보를 비동기적으로 받아오는 과정에서 순서가 섞이는 것 같습니다. 오늘 멘토링 시간 때 유저정보를 ChatDataSource에서 받아와도 된다고 했으니 이 부분은 나중에 리팩토링 할 예정입니다

### Screenshots(Optional)
https://user-images.githubusercontent.com/75964073/204852966-4b119bff-3120-477b-84c6-54ee78e1987c.mp4


