### PR TITLE
1:1 채팅방 생성 기능 구현

### DIFF
--- a/Mogakco/Sources/Domain/Repositories/ChatRoomRepositoryProtocol.swift
+++ b/Mogakco/Sources/Domain/Repositories/ChatRoomRepositoryProtocol.swift
@@ -14,4 +14,5 @@ protocol ChatRoomRepositoryProtocol {
     func create(studyID: String?, userIDs: [String]) -> Observable<ChatRoom>
     func updateIDs(id: String, userIDs: [String]) -> Observable<ChatRoom>
     func leave(user: User, chatRoom: ChatRoom) -> Observable<User>
+    func create(currentUserID: String, otherUserID: String) -> Observable<ChatRoom>
 }

--- a/Mogakco/Sources/Domain/UseCases/CreateChatRoomUseCase.swift
+++ b/Mogakco/Sources/Domain/UseCases/CreateChatRoomUseCase.swift
@@ -1,0 +1,31 @@
+//
+//  CreateChatRoomUseCase.swift
+//  Mogakco
+//
+//  Created by 김범수 on 2022/11/30.
+//  Copyright © 2022 Mogakco. All rights reserved.
+//
+
+import Foundation
+
+import RxSwift
+
+struct CreateChatRoomUseCase: CreateChatRoomUseCaseProtocol {
+    
+    private let chatRoomRepository: ChatRoomRepositoryProtocol
+    private let userRepository: UserRepositoryProtocol
+    private let disposeBag = DisposeBag()
+    
+    init(
+        chatRoomRepository: ChatRoomRepositoryProtocol,
+        userRepository: UserRepositoryProtocol
+    ) {
+        self.chatRoomRepository = chatRoomRepository
+        self.userRepository = userRepository
+    }
+    
+    func create(otherUser: User) -> Observable<ChatRoom> {
+        return userRepository.load()
+            .flatMap { chatRoomRepository.create(currentUserID: $0.id, otherUserID: otherUser.id) }
+    }
+}

--- a/Mogakco/Sources/Domain/UseCases/CreateStudyUseCase.swift
+++ b/Mogakco/Sources/Domain/UseCases/CreateStudyUseCase.swift
@@ -6,10 +6,11 @@
 //  Copyright © 2022 Mogakco. All rights reserved.
 //
 
-import RxSwift
 import Foundation
 
-class CreateStudyUseCase: CreateStudyUseCaseProtocol {
+import RxSwift
+
+struct CreateStudyUseCase: CreateStudyUseCaseProtocol {
     
     private let studyRepository: StudyRepositoryProtocol
     private let disposeBag = DisposeBag()

--- a/Mogakco/Sources/Domain/UseCases/Protocol/CreateChatRoomUseCaseProtocol.swift
+++ b/Mogakco/Sources/Domain/UseCases/Protocol/CreateChatRoomUseCaseProtocol.swift
@@ -1,0 +1,15 @@
+//
+//  CreateChatRoomUseCaseProtocol.swift
+//  Mogakco
+//
+//  Created by 김범수 on 2022/11/30.
+//  Copyright © 2022 Mogakco. All rights reserved.
+//
+
+import Foundation
+
+import RxSwift
+
+protocol CreateChatRoomUseCaseProtocol {
+    func create(otherUser: User) -> Observable<ChatRoom>
+}

--- a/Mogakco/Sources/Presentation/Common/Coordinator/ProfileTabCoordinator.swift
+++ b/Mogakco/Sources/Presentation/Common/Coordinator/ProfileTabCoordinator.swift
@@ -37,6 +37,17 @@ final class ProfileTabCoordinator: Coordinator, ProfileTabCoordinatorProtocol {
                     remoteUserDataSource: RemoteUserDataSource(provider: Provider.default),
                     chatRoomDataSource: ChatRoomDataSource(provider: Provider.default)
                 )
+            ),
+            createChatRoomUseCase: CreateChatRoomUseCase(
+                chatRoomRepository: ChatRoomRepository(
+                    chatRoomDataSource: ChatRoomDataSource(provider: Provider.default),
+                    remoteUserDataSource: RemoteUserDataSource(provider: Provider.default),
+                    studyDataSource: StudyDataSource(provider: Provider.default)
+                ),
+                userRepository: UserRepository(
+                    localUserDataSource: UserDefaultsUserDataSource(),
+                    remoteUserDataSource: RemoteUserDataSource(provider: Provider.default)
+                )
             )
         )
         let viewController = ProfileViewController(viewModel: viewModel)
@@ -58,7 +69,7 @@ final class ProfileTabCoordinator: Coordinator, ProfileTabCoordinatorProtocol {
         navigationController.tabBarController?.navigationController?.pushViewController(viewController, animated: true)
     }
     
-    func showChat() {
+    func showChatDetail(chatRoomID: String) {
     }
     
     func showSelectHashtag(kindHashtag: KindHashtag) {

--- a/Mogakco/Sources/Presentation/Common/Coordinator/Protocol/ProfileTabCoordinatorProtocol.swift
+++ b/Mogakco/Sources/Presentation/Common/Coordinator/Protocol/ProfileTabCoordinatorProtocol.swift
@@ -11,7 +11,7 @@ import Foundation
 protocol ProfileTabCoordinatorProtocol: AnyObject {
     func showProfile()
     func showEditProfile()
-    func showChat()
+    func showChatDetail(chatRoomID: String)
     func showSelectHashtag(kindHashtag: KindHashtag)
     func editFinished()
 }


### PR DESCRIPTION
### PR Type

- [x]  기능 추가 🔨
- [ ]  버그 수정 🐞
- [ ]  리팩토링 🚧
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [ ]  테스트 🔍
 

### Related Issue(작업 내용)

- resolve #218 
    - 1:1 채팅방 생성 기능을 구현하였습니다
    - 스터디가 없는 상대와 현재 유저 두명의 채팅방 존재 시 해당 채팅방으로 이동합니다
    - 그 외에은 채팅방을 새롭게 생성 후 이동합니다.

### 참고 사항
코드가 너무 길고 더럽네요... 서버 관련 긴 메소드들의 메소드 분리가 시급해보이네용,,

### Screenshots(Optional)
<img src="" width="50%">
