### PR TITLE
비밀번호 검증 조건 표시, 비밀번호 재확인 로직 수정

### DIFF
--- a/Mogakco/Sources/Presentation/Common/View/MessageTextField.swift
+++ b/Mogakco/Sources/Presentation/Common/View/MessageTextField.swift
@@ -90,4 +90,10 @@ extension Reactive where Base: MessageTextField {
             view.validation = validation
         }
     }
+    
+    var message: Binder<String> {
+        return Binder(self.base) { view, text in
+            view.message = text
+        }
+    }
 }

--- a/Mogakco/Sources/Presentation/Signup/ViewController/SetEmailViewController.swift
+++ b/Mogakco/Sources/Presentation/Signup/ViewController/SetEmailViewController.swift
@@ -71,10 +71,6 @@ final class SetEmailViewController: ViewController {
     
     // MARK: - Methods
     
-    override func viewDidLoad() {
-        super.viewDidLoad()
-    }
-    
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(true)
         title = Constant.navigationTitle

--- a/Mogakco/Sources/Presentation/Signup/ViewController/SetPasswordViewController.swift
+++ b/Mogakco/Sources/Presentation/Signup/ViewController/SetPasswordViewController.swift
@@ -71,10 +71,6 @@ final class SetPasswordViewController: ViewController {
     
     // MARK: - Methods
     
-    override func viewDidLoad() {
-        super.viewDidLoad()
-    }
-    
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(true)
         title = Constant.navigationTitle

--- a/Mogakco/Sources/Presentation/Signup/ViewController/SetPasswordViewController.swift
+++ b/Mogakco/Sources/Presentation/Signup/ViewController/SetPasswordViewController.swift
@@ -18,8 +18,11 @@ final class SetPasswordViewController: ViewController {
     enum Constant {
         static let navigationTitle = "회원가입"
         static let title = "안전한 계정을 위한\n비밀번호를 설정해주세요"
-        static let password = "비밀번호를 입력해주세요"
+        static let password = "영문, 숫자 조합 6자 이상"
         static let passwordCheck = "비밀번호 재입력"
+        static let passwordValidMessage = "안전한 비밀번호입니다."
+        static let passwordInvalidMessage = "영문, 숫자를 포함하여 총 6글자 이상이어야 합니다."
+        static let passwordCheckInvalidMessage = "비밀번호가 일치하지 않습니다."
         static let buttonTitle = "다음"
     }
     
@@ -34,7 +37,7 @@ final class SetPasswordViewController: ViewController {
     
     private let stackView = UIStackView().then {
         $0.axis = .vertical
-        $0.spacing = 8
+        $0.spacing = 10
     }
     
     private let passwordTextField = MessageTextField(isSecure: true).then {
@@ -92,15 +95,25 @@ final class SetPasswordViewController: ViewController {
         )
         
         let output = viewModel.transform(input: input)
-        
+
         output.passwordState
             .map { $0 ? TextField.Validation.valid : TextField.Validation.invalid }
             .bind(to: passwordTextField.rx.validation)
             .disposed(by: disposeBag)
         
+        output.passwordState
+            .map { $0 ? Constant.passwordValidMessage : Constant.passwordInvalidMessage }
+            .bind(to: passwordTextField.rx.message)
+            .disposed(by: disposeBag)
+        
         output.passwordCheckState
             .map { $0 ? TextField.Validation.valid : TextField.Validation.invalid }
             .bind(to: passwordCheckTextField.rx.validation)
+            .disposed(by: disposeBag)
+        
+        output.passwordCheckState
+            .map { $0 ? "" : Constant.passwordCheckInvalidMessage }
+            .bind(to: passwordCheckTextField.rx.message)
             .disposed(by: disposeBag)
         
         output.nextButtonEnabled

--- a/Mogakco/Sources/Presentation/Signup/ViewModel/SetPasswordViewModel.swift
+++ b/Mogakco/Sources/Presentation/Signup/ViewModel/SetPasswordViewModel.swift
@@ -43,22 +43,19 @@ final class SetPasswordViewModel: ViewModel {
         
         input.password
             .distinctUntilChanged()
-            .compactMap { [weak self] in
-                self?.validate(password: $0)
-            }
-            .subscribe(onNext: {
-                passwordState.onNext($0)
-            })
+            .withUnretained(self)
+            .map { $0.0.validate(password: $0.1) }
+            .bind(to: passwordState)
             .disposed(by: disposeBag)
         
         input.passwordCheck
             .distinctUntilChanged()
             .withLatestFrom(Observable.combineLatest(input.password, input.passwordCheck))
             .filter { !$0.0.isEmpty && !$0.1.isEmpty }
-            .map { $0.0 == $0.1 }
-            .subscribe(onNext: {
-                passwordCheckState.onNext($0)
-            })
+            .withUnretained(self)
+            .filter { $0.0.validate(password: $0.1.0) }
+            .map { $0.1.0 == $0.1.1 }
+            .bind(to: passwordCheckState)
             .disposed(by: disposeBag)
         
         input.nextButtonTapped


### PR DESCRIPTION
### PR Type

- [ ]  기능 추가 🔨
- [X]  버그 수정 🐞
- [X]  리팩토링 🚧
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [ ]  테스트 🔍
 

### Related Issue(작업 내용)

> 이슈 번호와 구현 내용 및 작업 했던 내역을 입력해주세요!
> 
- close #309
    - 간단한 수정입니다. 
    - 텍스트필드 placeholder에 비밀번호 검증 조건을 표시합니다.
    - 텍스트필드에 validation message를 추가했습니다.
    - 비밀번호가 유효하지 않으면 비밀번호 재확인 텍스트필드에 동일한 비밀번호를 입력해도 활성화되지 않습니다.

### Screenshots

<img src="https://user-images.githubusercontent.com/109145755/205633958-02678180-10c8-427a-a07d-e291dda5049d.png" width="35%"/>
