### PR TITLE
프로필 해시태그 편집 시 기존 해시태그 표시

### DIFF
--- a/Mogakco/Sources/Data/DataMapping/Language.swift
+++ b/Mogakco/Sources/Data/DataMapping/Language.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-enum Languages: String, CaseIterable, Hashtag {
+enum Language: String, CaseIterable, Hashtag {
     case cLang = "c"
     case cShop
     case cpp
@@ -29,30 +29,30 @@ enum Languages: String, CaseIterable, Hashtag {
     case visualBasic
     
     static func randomImageID() -> String {
-        guard let id = Languages.allCases.randomElement()?.id else { return "swift" }
+        guard let id = Language.allCases.randomElement()?.id else { return "swift" }
         return id
     }
     
     static func idToHashtag(id: String) -> Hashtag? {
         switch id {
-        case "c": return Languages.cLang
-        case "cShop": return Languages.cShop
-        case "cpp": return Languages.cpp
-        case "dart": return Languages.dart
-        case "go": return Languages.goLang
-        case "haskell": return Languages.haskell
-        case "javaScript": return Languages.javaScript
-        case "kotlin": return Languages.kotlin
-        case "matlab": return Languages.matlab
-        case "objectC": return Languages.objectC
-        case "php": return Languages.php
-        case "python": return Languages.python
-        case "r": return Languages.rLang
-        case "ruby": return Languages.ruby
-        case "rust": return Languages.rust
-        case "scratch": return Languages.scratch
-        case "swift": return Languages.swift
-        case "visualBasic": return Languages.visualBasic
+        case "c": return Language.cLang
+        case "cShop": return Language.cShop
+        case "cpp": return Language.cpp
+        case "dart": return Language.dart
+        case "go": return Language.goLang
+        case "haskell": return Language.haskell
+        case "javaScript": return Language.javaScript
+        case "kotlin": return Language.kotlin
+        case "matlab": return Language.matlab
+        case "objectC": return Language.objectC
+        case "php": return Language.php
+        case "python": return Language.python
+        case "r": return Language.rLang
+        case "ruby": return Language.ruby
+        case "rust": return Language.rust
+        case "scratch": return Language.scratch
+        case "swift": return Language.swift
+        case "visualBasic": return Language.visualBasic
         default: return nil
         }
     }

--- a/Mogakco/Sources/Data/DataSources/Local/HashtagDataSource.swift
+++ b/Mogakco/Sources/Data/DataSources/Local/HashtagDataSource.swift
@@ -25,7 +25,7 @@ struct HashtagDataSource: HashtagDataSourceProtocol {
     }
     
     private func loadLanguage() -> [Hashtag] {
-        return Languages.allCases
+        return Language.allCases
     }
     
     private func loadCareer() -> [Hashtag] {

--- a/Mogakco/Sources/Presentation/Chat/View/ChatCell.swift
+++ b/Mogakco/Sources/Presentation/Chat/View/ChatCell.swift
@@ -22,7 +22,6 @@ final class ChatCell: UICollectionViewCell, Identifiable {
         $0.isScrollEnabled = false
         $0.isEditable = false
     }
-    
     let bubbleContainer = UIView().then {
         $0.backgroundColor = .mogakcoColor.primarySecondary
         $0.layer.cornerRadius = 8

--- a/Mogakco/Sources/Presentation/Common/Coordinator/HashtagCoordinator.swift
+++ b/Mogakco/Sources/Presentation/Common/Coordinator/HashtagCoordinator.swift
@@ -38,7 +38,7 @@ final class HashtagCoordinator: BaseCoordinator<HashtagCoordinatorResult> {
     
     func showHashtag() {
         guard let viewModel = DIContainer.shared.container.resolve(HashtagFilterViewModel.self) else { return }
-        viewModel.selectedHashtag = selectedHashtag
+        viewModel.selectedHashtags = selectedHashtag
 
         viewModel.finish
             .map { HashtagCoordinatorResult.finish($0) }

--- a/Mogakco/Sources/Presentation/Common/Coordinator/ProfileCoordinator.swift
+++ b/Mogakco/Sources/Presentation/Common/Coordinator/ProfileCoordinator.swift
@@ -53,11 +53,11 @@ final class ProfileCoordinator: BaseCoordinator<ProfileCoordinatorResult> {
                 switch $0 {
                 case .editProfile:
                     self?.showEditProfile()
-                case .editHashtag(let kind):
-                    self?.showHashtag(kind: kind, selectedHashtag: [])
-                case .chatRoom(let id):
+                case let .editHashtag(kind: kind, selectedHashtags: selectedHashtags):
+                    self?.showHashtag(kind: kind, selectedHashtags: selectedHashtags)
+                case let .chatRoom(id):
                     self?.showChatRoom(id: id)
-                case .setting(let email):
+                case let .setting(email):
                     self?.setting(email: email)
                 case .back:
                     self?.finish.onNext(.back)
@@ -154,9 +154,9 @@ final class ProfileCoordinator: BaseCoordinator<ProfileCoordinatorResult> {
     
     // MARK: - 프로필 해시태그 수정
     
-    func showHashtag(kind: KindHashtag, selectedHashtag: [Hashtag]) {
+    func showHashtag(kind: KindHashtag, selectedHashtags: [Hashtag]) {
         guard let viewModel = DIContainer.shared.container.resolve(HashtagEditViewModel.self) else { return }
-        viewModel.selectedHashtag = selectedHashtag
+        viewModel.selectedHashtags = selectedHashtags
         
         viewModel.finish
             .subscribe(onNext: { [weak self] in

--- a/Mogakco/Sources/Presentation/Common/View/AnimationImageView.swift
+++ b/Mogakco/Sources/Presentation/Common/View/AnimationImageView.swift
@@ -24,7 +24,7 @@ final class AnimationImageView: UIView {
     }
     
     private func configRandomImage() {
-        imageView.image = UIImage(named: Languages.randomImageID() )
+        imageView.image = UIImage(named: Language.randomImageID() )
         addSubview(imageView)
         imageView.snp.makeConstraints {
             $0.edges.equalToSuperview()

--- a/Mogakco/Sources/Presentation/Hashtag/ViewModel/HashtagEditViewModel.swift
+++ b/Mogakco/Sources/Presentation/Hashtag/ViewModel/HashtagEditViewModel.swift
@@ -34,7 +34,7 @@ class HashtagEditViewModel: HashtagViewModel {
     }
     
     private func tapButton() {
-        let hashtagTitles = selectedHashtag.map { $0.id }
+        let hashtagTitles = selectedHashtags.map { $0.id }
         let changeProfile: Observable<Void>
         
         switch kind {

--- a/Mogakco/Sources/Presentation/Hashtag/ViewModel/HashtagFilterViewModel.swift
+++ b/Mogakco/Sources/Presentation/Hashtag/ViewModel/HashtagFilterViewModel.swift
@@ -19,7 +19,7 @@ class HashtagFilterViewModel: HashtagViewModel {
 
         input.nextButtonTapped
             .subscribe(onNext: { [weak self] in
-                let selectedHashtag = self?.selectedHashtag ?? []
+                let selectedHashtag = self?.selectedHashtags ?? []
                 self?.finish.onNext(selectedHashtag)
             })
             .disposed(by: disposeBag)

--- a/Mogakco/Sources/Presentation/Hashtag/ViewModel/HashtagSelectViewModel.swift
+++ b/Mogakco/Sources/Presentation/Hashtag/ViewModel/HashtagSelectViewModel.swift
@@ -28,7 +28,7 @@ class HashtagSelectedViewModel: HashtagViewModel {
         input.nextButtonTapped
             .withUnretained(self)
             .filter { $0.0.kind == .language }
-            .map { HashtagSelectedeNavigation.next($0.0.selectedHashtag) }
+            .map { HashtagSelectedeNavigation.next($0.0.selectedHashtags) }
             .bind(to: navigation)
             .disposed(by: disposeBag)
 
@@ -48,7 +48,7 @@ class HashtagSelectedViewModel: HashtagViewModel {
 
     private func signup() {
         guard let languageProps = languageProps else { return }
-        let careers = selectedHashtag.map { $0.id }
+        let careers = selectedHashtags.map { $0.id }
         let signupProps = languageProps.toSignupProps(careers: careers)
         signUseCase?.signup(signupProps: signupProps)
             .subscribe { [weak self] _ in

--- a/Mogakco/Sources/Presentation/Hashtag/ViewModel/HashtagViewModel.swift
+++ b/Mogakco/Sources/Presentation/Hashtag/ViewModel/HashtagViewModel.swift
@@ -26,7 +26,7 @@ class HashtagViewModel: ViewModel {
     
     var hashTagUsecase: HashtagUseCaseProtocol?
     var disposeBag = DisposeBag()
-    var selectedHashtag: [Hashtag] = []
+    var selectedHashtags: [Hashtag] = []
     let badgeList = BehaviorSubject<[Hashtag]>(value: [])
     var kind: KindHashtag = .language
     
@@ -70,7 +70,7 @@ class HashtagViewModel: ViewModel {
     
     func isSelected(index: Int) -> Bool {
         guard let hashtag = cellInfo(index: index) else { return false }
-        if selectedHashtag.contains(where: { $0.id == hashtag.id }) { return true }
+        if selectedHashtags.contains(where: { $0.id == hashtag.id }) { return true }
         return false
     }
     
@@ -85,10 +85,10 @@ class HashtagViewModel: ViewModel {
     private func selectHashtag(index: Int) {
         guard let hashTag = cellInfo(index: index) else { return }
         
-        if let removeIndex = selectedHashtag.firstIndex(where: { $0.id == hashTag.id }) {
-            selectedHashtag.remove(at: removeIndex)
+        if let removeIndex = selectedHashtags.firstIndex(where: { $0.id == hashTag.id }) {
+            selectedHashtags.remove(at: removeIndex)
         } else {
-            selectedHashtag.append(hashTag)
+            selectedHashtags.append(hashTag)
         }
     }
 }

--- a/Mogakco/Sources/Presentation/Study/View/StudyCell.swift
+++ b/Mogakco/Sources/Presentation/Study/View/StudyCell.swift
@@ -136,7 +136,7 @@ final class StudyCell: UICollectionViewCell, Identifiable {
         tags.forEach {
             let label = UILabel()
             label.font = UIFont(name: SFPro.regular.rawValue, size: 12)
-            label.text = Languages(rawValue: $0)?.title
+            label.text = Language(rawValue: $0)?.title
             hashtagStackView.addArrangedSubview(label)
         }
     }


### PR DESCRIPTION
### PR Type

- [x]  기능 추가 🔨
- [ ]  버그 수정 🐞
- [x]  리팩토링 🚧
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [ ]  테스트 🔍
 

### Related Issue(작업 내용)

- resolve #363 
    - 프로필 화면에서 해시태그 편집화면으로 이동 시 selectedHashtags를 함께 전달하도록 구현하였습니다.
- 언어 관련 객체의 이름을 수정하였습니다 (Languages -> Language)

### 참고 사항
추후 User 내 Hashtag 관련 프로퍼티를 String -> Hashtag로 리팩토링하는게 좋을 것 같아 [이슈](https://github.com/boostcampwm-2022/iOS04-Mogakco/issues/279)를 생성해두었습니다.


### Screenshots(Optional)

https://user-images.githubusercontent.com/73675540/206099773-489b0238-60fd-4092-9a77-8764cece3dde.mp4

