### PR TITLE
프로필 편집 화면 로딩 딜레이 오류 개선

### DIFF
--- a/Mogakco/Sources/Presentation/Profile/ViewController/EditProfileViewController.swift
+++ b/Mogakco/Sources/Presentation/Profile/ViewController/EditProfileViewController.swift
@@ -49,7 +49,7 @@ final class EditProfileViewController: ViewController {
     }
     
     private var viewModel: EditProfileViewModel
-    private let imagePicker = UIImagePickerController()
+    private var imagePicker: UIImagePickerController?
     private let selectedProfileImage = PublishRelay<UIImage>()
     
     init(viewModel: EditProfileViewModel) {
@@ -63,13 +63,17 @@ final class EditProfileViewController: ViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        configureImagePicker()
         hideKeyboardWhenTappedAround()
     }
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         navigationController?.isNavigationBarHidden = false
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        configureImagePicker()
     }
     
     override func viewWillDisappear(_ animated: Bool) {
@@ -203,11 +207,13 @@ final class EditProfileViewController: ViewController {
 
 private extension EditProfileViewController {
     func configureImagePicker() {
-        imagePicker.allowsEditing = true
-        imagePicker.delegate = self
+        imagePicker = UIImagePickerController()
+        imagePicker?.allowsEditing = true
+        imagePicker?.delegate = self
     }
     
     func presentImagePicker() {
+        guard let imagePicker = imagePicker else { return }
         present(imagePicker, animated: true)
     }
 }


### PR DESCRIPTION
### PR Type

- [ ]  기능 추가 🔨
- [x]  버그 수정 🐞
- [ ]  리팩토링 🚧
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [ ]  테스트 🔍
 

### Related Issue(작업 내용)

- resolve #356 
    - 프로필 편집 화면 로딩 딜레이 오류 해결

### 참고 사항
[UIImagePicker Init Delay](https://stackoverflow.com/questions/20353492/uiimagepickercontroller-really-slow-when-calling-alloc-init) 이슈가 있어 viewDidAppear에서 초기화하여 오류를 개선했습니다

이미지 피커 라이브러리는 도입하면 정말 금방이라 도입하면 좋겠다는 의견이 나오면 진행하도록 하겠습니다!

### Screenshots(Optional)

https://user-images.githubusercontent.com/73675540/206112964-4c7706f1-a5ff-4cb3-9045-b4be038d680d.MP4

