### PR TITLE
푸쉬 알림 오류 개선

### DIFF
--- a/Mogakco/Sources/App/DIContainer.swift
+++ b/Mogakco/Sources/App/DIContainer.swift
@@ -65,7 +65,6 @@ final class DIContainer {
             repository.chatRoomDataSource = resolver.resolve(ChatRoomDataSourceProtocol.self)
             repository.remoteUserDataSource = resolver.resolve(RemoteUserDataSourceProtocol.self)
             repository.studyDataSource = resolver.resolve(StudyDataSourceProtocol.self)
-            repository.pushNotificationService = resolver.resolve(PushNotificationServiceProtocol.self)
             return repository
         }
         container.register(HashtagRepositoryProtocol.self) { resolver in

--- a/Mogakco/Sources/App/DIContainer.swift
+++ b/Mogakco/Sources/App/DIContainer.swift
@@ -65,6 +65,7 @@ final class DIContainer {
             repository.chatRoomDataSource = resolver.resolve(ChatRoomDataSourceProtocol.self)
             repository.remoteUserDataSource = resolver.resolve(RemoteUserDataSourceProtocol.self)
             repository.studyDataSource = resolver.resolve(StudyDataSourceProtocol.self)
+            repository.pushNotificationService = resolver.resolve(PushNotificationServiceProtocol.self)
             return repository
         }
         container.register(HashtagRepositoryProtocol.self) { resolver in
@@ -79,6 +80,7 @@ final class DIContainer {
             repository.chatRoomDataSource = resolver.resolve(ChatRoomDataSourceProtocol.self)
             repository.localUserDataSource = resolver.resolve(LocalUserDataSourceProtocol.self)
             repository.reportDataSource = resolver.resolve(ReportDataSourceProtocol.self)
+            repository.pushNotificationService = resolver.resolve(PushNotificationServiceProtocol.self)
             return repository
         }
         container.register(UserRepositoryProtocol.self) { resolver in

--- a/Mogakco/Sources/App/DIContainer.swift
+++ b/Mogakco/Sources/App/DIContainer.swift
@@ -214,6 +214,8 @@ final class DIContainer {
             let viewModel = ChatViewModel()
             viewModel.chatUseCase = resolver.resolve(ChatUseCaseProtocol.self)
             viewModel.leaveStudyUseCase = resolver.resolve(LeaveStudyUseCaseProtocol.self)
+            viewModel.subscribePushNotificationUseCase = resolver.resolve(SubscribePushNotificationUseCaseProtocol.self)
+            viewModel.unsubscribePushNotificationUseCase = resolver.resolve(UnsubscribePushNotificationUseCaseProtocol.self)
             return viewModel
         }
         container.register(ChatListViewModel.self) { resolver in

--- a/Mogakco/Sources/App/DIContainer.swift
+++ b/Mogakco/Sources/App/DIContainer.swift
@@ -197,6 +197,16 @@ final class DIContainer {
             useCase.tokenRepository = resolver.resolve(TokenRepositoryProtocol.self)
             return useCase
         }
+        container.register(SubscribePushNotificationUseCaseProtocol.self) { resolver in
+            var useCase = SubscribePushNotificationUseCase()
+            useCase.pushNotificationService = resolver.resolve(PushNotificationServiceProtocol.self)
+            return useCase
+        }
+        container.register(UnsubscribePushNotificationUseCaseProtocol.self) { resolver in
+            var useCase = UnsubscribePushNotificationUseCase()
+            useCase.pushNotificationService = resolver.resolve(PushNotificationServiceProtocol.self)
+            return useCase
+        }
     }
     
     private func registerViewModels() {

--- a/Mogakco/Sources/Data/DataSources/Protocol/PushNotificationServiceProtocol.swift
+++ b/Mogakco/Sources/Data/DataSources/Protocol/PushNotificationServiceProtocol.swift
@@ -14,7 +14,7 @@ protocol PushNotificationServiceProtocol {
     // 특정 Topic을 구독하고 있는 유저들에게 푸쉬 알림 전송
     func sendTopic(request: PushNotificationRequestDTO) -> Observable<EmptyResponse>
     // Topic 구독
-    func subscribeTopic(topic: String)
+    func subscribeTopic(topic: String) -> Observable<Void>
     // Topic 구독 해제
-    func unsubscribeTopic(topic: String)
+    func unsubscribeTopic(topic: String) -> Observable<Void>
 }

--- a/Mogakco/Sources/Data/DataSources/Protocol/PushNotificationServiceProtocol.swift
+++ b/Mogakco/Sources/Data/DataSources/Protocol/PushNotificationServiceProtocol.swift
@@ -9,10 +9,12 @@
 import RxSwift
 
 protocol PushNotificationServiceProtocol {
-    // FCM Token을 이용하여 특정 유저에게 푸쉬 알림을 보내는 API
+    // FCM Token을 이용하여 특정 유저에게 푸쉬 알림 전송
     func send(request: PushNotificationRequestDTO) -> Observable<EmptyResponse>
-    // 특정 Topic을 구독하고 있는 유저들에게 푸쉬 알림을 보내는 API
+    // 특정 Topic을 구독하고 있는 유저들에게 푸쉬 알림 전송
     func sendTopic(request: PushNotificationRequestDTO) -> Observable<EmptyResponse>
-    // Topic을 구독하는 API
+    // Topic 구독
     func subscribeTopic(topic: String)
+    // Topic 구독 해제
+    func unsubscribeTopic(topic: String)
 }

--- a/Mogakco/Sources/Data/DataSources/Remote/PushNotificationService.swift
+++ b/Mogakco/Sources/Data/DataSources/Remote/PushNotificationService.swift
@@ -34,6 +34,16 @@ struct PushNotificationService: PushNotificationServiceProtocol {
             }
         }
     }
+    
+    func unsubscribeTopic(topic: String) {
+        Messaging.messaging().unsubscribe(fromTopic: topic) { error in
+            if let error = error {
+                print("Message Subscribe Error \(error)")
+            } else {
+                print("Message Subscribe succeeded")
+            }
+        }
+    }
 }
 
 enum PushNotificationTarget {

--- a/Mogakco/Sources/Data/DataSources/Remote/PushNotificationService.swift
+++ b/Mogakco/Sources/Data/DataSources/Remote/PushNotificationService.swift
@@ -25,23 +25,27 @@ struct PushNotificationService: PushNotificationServiceProtocol {
         return provider.request(PushNotificationTarget.send(request))
     }
     
-    func subscribeTopic(topic: String) {
-        Messaging.messaging().subscribe(toTopic: topic) { error in
-            if let error = error {
-                print("Message Subscribe Error \(error)")
-            } else {
-                print("Message Subscribe succeeded")
+    func subscribeTopic(topic: String) -> Observable<Void> {
+        return Observable.create { emitter in
+            Messaging.messaging().subscribe(toTopic: topic) { error in
+                if let error = error {
+                    emitter.onError(error)
+                }
+                emitter.onNext(())
             }
+            return Disposables.create()
         }
     }
     
-    func unsubscribeTopic(topic: String) {
-        Messaging.messaging().unsubscribe(fromTopic: topic) { error in
-            if let error = error {
-                print("Message Subscribe Error \(error)")
-            } else {
-                print("Message Subscribe succeeded")
+    func unsubscribeTopic(topic: String) -> Observable<Void> {
+        return Observable.create { emitter in
+            Messaging.messaging().unsubscribe(fromTopic: topic) { error in
+                if let error = error {
+                    emitter.onError(error)
+                }
+                emitter.onNext(())
             }
+            return Disposables.create()
         }
     }
 }

--- a/Mogakco/Sources/Data/Repositories/ChatRoomRepository.swift
+++ b/Mogakco/Sources/Data/Repositories/ChatRoomRepository.swift
@@ -16,6 +16,7 @@ struct ChatRoomRepository: ChatRoomRepositoryProtocol {
     var chatRoomDataSource: ChatRoomDataSourceProtocol?
     var remoteUserDataSource: RemoteUserDataSourceProtocol?
     var studyDataSource: StudyDataSourceProtocol?
+    var pushNotificationService: PushNotificationServiceProtocol?
 
     func create(studyID: String?, userIDs: [String]) -> Observable<ChatRoom> {
         let request = CreateChatRoomRequestDTO(
@@ -103,6 +104,7 @@ struct ChatRoomRepository: ChatRoomRepositoryProtocol {
                 request: .init(userIDs: $0.userIDs.filter { $0 != user.id })
             ) ?? .empty()
             }
+            .flatMap { _ in pushNotificationService?.unsubscribeTopic(topic: chatRoom.id) ?? .empty() }
             .map { _ in () } ?? .empty()
         
         let userUpdated = Observable.zip(studyUpdated, chatRoomUpdated)

--- a/Mogakco/Sources/Data/Repositories/ChatRoomRepository.swift
+++ b/Mogakco/Sources/Data/Repositories/ChatRoomRepository.swift
@@ -16,7 +16,6 @@ struct ChatRoomRepository: ChatRoomRepositoryProtocol {
     var chatRoomDataSource: ChatRoomDataSourceProtocol?
     var remoteUserDataSource: RemoteUserDataSourceProtocol?
     var studyDataSource: StudyDataSourceProtocol?
-    var pushNotificationService: PushNotificationServiceProtocol?
 
     func create(studyID: String?, userIDs: [String]) -> Observable<ChatRoom> {
         let request = CreateChatRoomRequestDTO(
@@ -36,15 +35,6 @@ struct ChatRoomRepository: ChatRoomRepositoryProtocol {
         let chatRoomsSb = chatRoomDataSource?.list()
             .map { $0.documents.map { $0.toDomain() } }
             .map { $0.filter { ids.contains($0.id) } } ?? .empty()
-        
-        // 채팅방 푸쉬 알림 구독
-        chatRoomsSb
-            .subscribe(onNext: {
-                $0.forEach {
-                    self.pushNotificationService?.subscribeTopic(topic: $0.id)
-                }
-            })
-            .disposed(by: disposeBag)
         
         // 최근 메세지 호출
         let latestChatChatRoomsSb = BehaviorSubject<[ChatRoom]>(value: [])

--- a/Mogakco/Sources/Data/Repositories/StudyRepository.swift
+++ b/Mogakco/Sources/Data/Repositories/StudyRepository.swift
@@ -19,6 +19,7 @@ struct StudyRepository: StudyRepositoryProtocol {
     var remoteUserDataSource: RemoteUserDataSourceProtocol?
     var chatRoomDataSource: ChatRoomDataSourceProtocol?
     var reportDataSource: ReportDataSourceProtocol?
+    var pushNotificationService: PushNotificationServiceProtocol?
     private let disposeBag = DisposeBag()
 
     func list(sort: StudySort, filters: [StudyFilter]) -> Observable<[Study]> {
@@ -254,6 +255,7 @@ struct StudyRepository: StudyRepositoryProtocol {
                         )
                     ) ?? .empty()
                 }
+                .flatMap { _ in pushNotificationService?.unsubscribeTopic(topic: id) ?? .empty() }
             
             Observable.combineLatest(
                 updateUser,

--- a/Mogakco/Sources/Data/Repositories/StudyRepository.swift
+++ b/Mogakco/Sources/Data/Repositories/StudyRepository.swift
@@ -90,6 +90,9 @@ struct StudyRepository: StudyRepositoryProtocol {
                 .flatMap {
                     chatRoomDataSource?.create(request: $0) ?? .empty()
                 }
+                .flatMap {
+                    pushNotificationService?.subscribeTopic(topic: $0.toDomain().id) ?? .empty()
+                }
             
             let updateUser = user
                 .flatMap { user in

--- a/Mogakco/Sources/Domain/UseCases/Protocol/SubscribePushNotificationUseCaseProtocol.swift
+++ b/Mogakco/Sources/Domain/UseCases/Protocol/SubscribePushNotificationUseCaseProtocol.swift
@@ -1,0 +1,13 @@
+//
+//  SubscribePushNotificationUseCaseProtocol.swift
+//  Mogakco
+//
+//  Created by 김범수 on 2022/12/07.
+//  Copyright © 2022 Mogakco. All rights reserved.
+//
+
+import Foundation
+
+protocol SubscribePushNotificationUseCaseProtocol {
+    func excute(topic: String)
+}

--- a/Mogakco/Sources/Domain/UseCases/Protocol/SubscribePushNotificationUseCaseProtocol.swift
+++ b/Mogakco/Sources/Domain/UseCases/Protocol/SubscribePushNotificationUseCaseProtocol.swift
@@ -6,8 +6,8 @@
 //  Copyright © 2022 Mogakco. All rights reserved.
 //
 
-import Foundation
+import RxSwift
 
 protocol SubscribePushNotificationUseCaseProtocol {
-    func excute(topic: String)
+    func excute(topic: String) -> Observable<Void>
 }

--- a/Mogakco/Sources/Domain/UseCases/Protocol/UnsubscribePushNotificationUseCaseProtocol.swift
+++ b/Mogakco/Sources/Domain/UseCases/Protocol/UnsubscribePushNotificationUseCaseProtocol.swift
@@ -6,8 +6,8 @@
 //  Copyright © 2022 Mogakco. All rights reserved.
 //
 
-import Foundation
+import RxSwift
 
 protocol UnsubscribePushNotificationUseCaseProtocol {
-    func excute(topic: String)
+    func excute(topic: String) -> Observable<Void>
 }

--- a/Mogakco/Sources/Domain/UseCases/Protocol/UnsubscribePushNotificationUseCaseProtocol.swift
+++ b/Mogakco/Sources/Domain/UseCases/Protocol/UnsubscribePushNotificationUseCaseProtocol.swift
@@ -1,0 +1,13 @@
+//
+//  UnsubscribePushNotificationUseCaseProtocol.swift
+//  Mogakco
+//
+//  Created by 김범수 on 2022/12/07.
+//  Copyright © 2022 Mogakco. All rights reserved.
+//
+
+import Foundation
+
+protocol UnsubscribePushNotificationUseCaseProtocol {
+    func excute(topic: String)
+}

--- a/Mogakco/Sources/Domain/UseCases/SubscribePushNotificationUseCase.swift
+++ b/Mogakco/Sources/Domain/UseCases/SubscribePushNotificationUseCase.swift
@@ -1,0 +1,18 @@
+//
+//  SubscribePushNotificationUseCase.swift
+//  Mogakco
+//
+//  Created by 김범수 on 2022/12/07.
+//  Copyright © 2022 Mogakco. All rights reserved.
+//
+
+import Foundation
+
+struct SubscribePushNotificationUseCase: SubscribePushNotificationUseCaseProtocol {
+    
+    var pushNotificationService: PushNotificationServiceProtocol?
+    
+    func excute(topic: String) {
+        pushNotificationService?.subscribeTopic(topic: topic)
+    }
+}

--- a/Mogakco/Sources/Domain/UseCases/SubscribePushNotificationUseCase.swift
+++ b/Mogakco/Sources/Domain/UseCases/SubscribePushNotificationUseCase.swift
@@ -6,13 +6,13 @@
 //  Copyright © 2022 Mogakco. All rights reserved.
 //
 
-import Foundation
+import RxSwift
 
 struct SubscribePushNotificationUseCase: SubscribePushNotificationUseCaseProtocol {
     
     var pushNotificationService: PushNotificationServiceProtocol?
     
-    func excute(topic: String) {
-        pushNotificationService?.subscribeTopic(topic: topic)
+    func excute(topic: String) -> Observable<Void> {
+        return pushNotificationService?.subscribeTopic(topic: topic) ?? .empty()
     }
 }

--- a/Mogakco/Sources/Domain/UseCases/UnsubscribePushNotificationUseCase.swift
+++ b/Mogakco/Sources/Domain/UseCases/UnsubscribePushNotificationUseCase.swift
@@ -6,13 +6,13 @@
 //  Copyright © 2022 Mogakco. All rights reserved.
 //
 
-import Foundation
+import RxSwift
 
 struct UnsubscribePushNotificationUseCase: UnsubscribePushNotificationUseCaseProtocol {
     
     var pushNotificationService: PushNotificationServiceProtocol?
     
-    func excute(topic: String) {
-        pushNotificationService?.unsubscribeTopic(topic: topic)
+    func excute(topic: String) -> Observable<Void> {
+        return pushNotificationService?.unsubscribeTopic(topic: topic) ?? .empty()
     }
 }

--- a/Mogakco/Sources/Domain/UseCases/UnsubscribePushNotificationUseCase.swift
+++ b/Mogakco/Sources/Domain/UseCases/UnsubscribePushNotificationUseCase.swift
@@ -1,0 +1,18 @@
+//
+//  UnsubscribePushNotificationUseCase.swift
+//  Mogakco
+//
+//  Created by 김범수 on 2022/12/07.
+//  Copyright © 2022 Mogakco. All rights reserved.
+//
+
+import Foundation
+
+struct UnsubscribePushNotificationUseCase: UnsubscribePushNotificationUseCaseProtocol {
+    
+    var pushNotificationService: PushNotificationServiceProtocol?
+    
+    func excute(topic: String) {
+        pushNotificationService?.unsubscribeTopic(topic: topic)
+    }
+}

--- a/Mogakco/Sources/Presentation/Chat/ViewController/ChatViewController.swift
+++ b/Mogakco/Sources/Presentation/Chat/ViewController/ChatViewController.swift
@@ -88,11 +88,6 @@ final class ChatViewController: ViewController {
         navigationController?.isNavigationBarHidden = false
     }
     
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-        navigationController?.isNavigationBarHidden = true
-    }
-    
     override var canBecomeFirstResponder: Bool {
         return true
     }
@@ -116,6 +111,12 @@ final class ChatViewController: ViewController {
     
     override func bind() {
         let input = ChatViewModel.Input(
+            viewWillAppear: rx.viewWillAppear.map { _ in () }.asObservable(),
+            viewWillDisappear: rx.viewWillDisappear.map { _ in () }.asObservable(),
+            willEnterForeground: NotificationCenter.default
+                .rx.notification(UIApplication.willEnterForegroundNotification).map { _ in () },
+            didEnterBackground: NotificationCenter.default
+                .rx.notification(UIApplication.didEnterBackgroundNotification).map { _ in () },
             backButtonDidTap: backButton.rx.tap.asObservable(),
             studyInfoButtonDidTap: studyInfoButton.rx.tap.asObservable(),
             selectedSidebar: sidebarView.tableView.rx.itemSelected.asObservable(),
@@ -123,7 +124,6 @@ final class ChatViewController: ViewController {
             inputViewText: messageInputView.messageInputTextView.rx.text.orEmpty.asObservable(),
             pagination: collectionView.refreshControl?.rx.controlEvent(.valueChanged).asObservable()
         )
-
         let output = viewModel.transform(input: input)
         
         Driver<[ChatSidebarMenu]>.just(ChatSidebarMenu.allCases)
@@ -133,9 +133,7 @@ final class ChatViewController: ViewController {
                     for: IndexPath(row: index, section: 0)) as? ChatSidebarTableViewCell else {
                     return UITableViewCell()
                 }
-
                 cell.menuLabel.text = menu.rawValue
-
                 return cell
             }
             .disposed(by: disposeBag)

--- a/Mogakco/Sources/Presentation/Chat/ViewModel/ChatViewModel.swift
+++ b/Mogakco/Sources/Presentation/Chat/ViewModel/ChatViewModel.swift
@@ -159,8 +159,8 @@ final class ChatViewModel: ViewModel {
             input.willEnterForeground
         )
         .withUnretained(self)
-        .subscribe(onNext: { viewModel, _ in
-            viewModel.unsubscribePushNotificationUseCase?.excute(topic: viewModel.chatRoomID)
+        .flatMap { $0.0.unsubscribePushNotificationUseCase?.excute(topic: $0.0.chatRoomID) ?? .empty() }
+        .subscribe(onNext: { _ in
         })
         .disposed(by: disposeBag)
         
@@ -170,8 +170,8 @@ final class ChatViewModel: ViewModel {
             input.didEnterBackground
         )
         .withUnretained(self)
-        .subscribe(onNext: { viewModel, _ in
-            viewModel.subscribePushNotificationUseCase?.excute(topic: viewModel.chatRoomID)
+        .flatMap { $0.0.subscribePushNotificationUseCase?.excute(topic: $0.0.chatRoomID) ?? .empty() }
+        .subscribe(onNext: { _ in
         })
         .disposed(by: disposeBag)
     }

--- a/Mogakco/Sources/Presentation/Chat/ViewModel/ChatViewModel.swift
+++ b/Mogakco/Sources/Presentation/Chat/ViewModel/ChatViewModel.swift
@@ -131,7 +131,8 @@ final class ChatViewModel: ViewModel {
                             message: message,
                             chatRoomID: self.chatRoomID,
                             date: Date().toInt(dateFormat: Format.chatDateFormat),
-                            readUserIDs: [user.id]
+                            readUserIDs: [user.id],
+                            user: user
                         ),
                         to: self.chatRoomID
                     )


### PR DESCRIPTION
### PR Type

- [ ]  기능 추가 🔨
- [x]  버그 수정 🐞
- [ ]  리팩토링 🚧
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [ ]  테스트 🔍
 

### Related Issue(작업 내용)

- resolve #366 
    - 자기 자신이 전송한 메세지가 푸쉬 알림이 오는 오류를 개선하였습니다
    - 채팅방 내에 있을 시 푸쉬 알림이 오는 오류를 개선하였습니다.

### 참고 사항
``` swift
// 채팅방 들어올 시 -> 푸쉬 알림 구독 해제
Observable.merge(
    input.viewWillAppear,
    input.willEnterForeground
)
.withUnretained(self)
.subscribe(onNext: { viewModel, _ in
    viewModel.unsubscribePushNotificationUseCase?.excute(topic: viewModel.chatRoomID)
})
.disposed(by: disposeBag)

// 채팅방 나갈 시 -> 푸쉬 알림 구독
Observable.merge(
    input.viewWillDisappear,
    input.didEnterBackground
)
.withUnretained(self)
.subscribe(onNext: { viewModel, _ in
    viewModel.subscribePushNotificationUseCase?.excute(topic: viewModel.chatRoomID)
})
.disposed(by: disposeBag)
```

채팅방 내부에 있을 시, 나갈 시에 해당 채팅방에 대한 푸쉬 알림 구독 여부를 변경하여 푸쉬 알림을 받습니다
백그라운드, 포그라운드에 대한 예외도 대응하였습니다

### Screenshots(Optional)

https://user-images.githubusercontent.com/73675540/206123622-a3ec6839-ec75-4d6f-a41f-0ffe43a3db37.MP4


### 추가
채팅 전송 시 전송 유저의 이름이 뜨도록 개선하였습니다

<img src="https://user-images.githubusercontent.com/73675540/206125494-8ff0b36f-7a12-4a7f-84a2-9daa23229de8.jpeg" width="50%">

