### PR TITLE
스터디 상세 버그 수정

### DIFF
--- a/Mogakco/Sources/Presentation/Chat/ViewController/ChatListViewController.swift
+++ b/Mogakco/Sources/Presentation/Chat/ViewController/ChatListViewController.swift
@@ -74,6 +74,7 @@ final class ChatListViewController: UIViewController {
                     for: IndexPath(row: index, section: 0)) as? ChatRoomTableViewCell else {
                     return UITableViewCell()
                 }
+                cell.selectionStyle = .none
                 cell.configure(chatRoom: chatRoom)
                 return cell
             }

--- a/Mogakco/Sources/Presentation/Common/View/AnimationImageView.swift
+++ b/Mogakco/Sources/Presentation/Common/View/AnimationImageView.swift
@@ -11,11 +11,11 @@ import UIKit
 import SnapKit
 
 final class AnimationImageView: UIView {
-    let imageView = UIImageView()
+    let iconImage = UIImageView()
     
-    override init(frame: CGRect) {
+    init(frame: CGRect, image: UIImage?) {
         super.init(frame: frame)
-        configRandomImage()
+        configImage(image: image)
         addRotation()
     }
     
@@ -23,10 +23,10 @@ final class AnimationImageView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
     
-    private func configRandomImage() {
-        imageView.image = UIImage(named: Language.randomImageID() )
-        addSubview(imageView)
-        imageView.snp.makeConstraints {
+    private func configImage(image: UIImage?) {
+        iconImage.image = image
+        addSubview(iconImage)
+        iconImage.snp.makeConstraints {
             $0.edges.equalToSuperview()
         }
     }
@@ -40,10 +40,10 @@ final class AnimationImageView: UIView {
         rotation.toValue = Double.pi / 180 * 360 * randomRotaionDirection
         rotation.duration = CFTimeInterval(AnimationView.Animation.rotateDuration)
         rotation.repeatCount = Float.infinity
-        imageView.layer.add(rotation, forKey: "rotationAnimation")
+        iconImage.layer.add(rotation, forKey: "rotationAnimation")
     }
     
     func removeRotation() {
-        imageView.layer.removeAnimation(forKey: "rotationAnimation")
+        iconImage.layer.removeAnimation(forKey: "rotationAnimation")
     }
 }

--- a/Mogakco/Sources/Presentation/Common/View/AnimationView.swift
+++ b/Mogakco/Sources/Presentation/Common/View/AnimationView.swift
@@ -64,7 +64,7 @@ final class AnimationView: UIView {
             Languages.python.id,
             Languages.ruby.id
         ].forEach {
-            let imageView = AnimationImageView(frame: randomPosition(),image: UIImage(named: $0))
+            let imageView = AnimationImageView(frame: randomPosition(), image: UIImage(named: $0))
             addSubview(imageView)
             animationImages.append(imageView)
             moveView(targetView: imageView)

--- a/Mogakco/Sources/Presentation/Common/View/AnimationView.swift
+++ b/Mogakco/Sources/Presentation/Common/View/AnimationView.swift
@@ -58,11 +58,11 @@ final class AnimationView: UIView {
     
     private func addImages() {
         [
-            Languages.swift.id,
-            Languages.cpp.id,
-            Languages.javaScript.id,
-            Languages.python.id,
-            Languages.ruby.id
+            Language.swift.id,
+            Language.cpp.id,
+            Language.javaScript.id,
+            Language.python.id,
+            Language.ruby.id
         ].forEach {
             let imageView = AnimationImageView(frame: randomPosition(), image: UIImage(named: $0))
             addSubview(imageView)

--- a/Mogakco/Sources/Presentation/Common/View/AnimationView.swift
+++ b/Mogakco/Sources/Presentation/Common/View/AnimationView.swift
@@ -57,8 +57,14 @@ final class AnimationView: UIView {
     }
     
     private func addImages() {
-        (0..<Animation.iconCount).forEach { _ in
-            let imageView = AnimationImageView(frame: randomPosition())
+        [
+            Languages.swift.id,
+            Languages.cpp.id,
+            Languages.javaScript.id,
+            Languages.python.id,
+            Languages.ruby.id
+        ].forEach {
+            let imageView = AnimationImageView(frame: randomPosition(),image: UIImage(named: $0))
             addSubview(imageView)
             animationImages.append(imageView)
             moveView(targetView: imageView)

--- a/Mogakco/Sources/Presentation/Study/View/ParticipantCell.swift
+++ b/Mogakco/Sources/Presentation/Study/View/ParticipantCell.swift
@@ -91,6 +91,6 @@ final class ParticipantCell: UICollectionViewCell, Identifiable {
             imageView.setPhoto(Image.profileDefault)
         }
         userNameLabel.text = user?.name ?? "None"
-        userDescriptionLabel.text = user?.introduce ?? "None"
+        userDescriptionLabel.text = user?.languages.first ?? "None"
     }
 }

--- a/Mogakco/Sources/Presentation/Study/ViewController/StudyDetailViewController.swift
+++ b/Mogakco/Sources/Presentation/Study/ViewController/StudyDetailViewController.swift
@@ -146,7 +146,7 @@ final class StudyDetailViewController: UIViewController {
     func bind() {
         let input = StudyDetailViewModel.Input(
             studyJoinButtonTapped: studyJoinButton.rx.tap.asObservable(),
-            participantCellTapped: participantsCollectionView.rx.itemSelected.asObservable(),
+            selectParticipantCell: participantsCollectionView.rx.modelSelected(User.self).asObservable(),
             backButtonTapped: backButton.rx.tap.asObservable(),
             reportButtonTapped: report.asObservable()
         )

--- a/Mogakco/Sources/Presentation/Study/ViewController/StudyDetailViewController.swift
+++ b/Mogakco/Sources/Presentation/Study/ViewController/StudyDetailViewController.swift
@@ -12,7 +12,7 @@ import Then
 import RxSwift
 import RxCocoa
 
-final class StudyDetailViewController: ViewController {
+final class StudyDetailViewController: UIViewController {
     
     private lazy var scrollView = UIScrollView()
     private lazy var contentsView = UIView()
@@ -103,7 +103,7 @@ final class StudyDetailViewController: ViewController {
     
     private let report = PublishSubject<Void>()
     var viewModel: StudyDetailViewModel
-    var disposebag = DisposeBag()
+    var disposeBag = DisposeBag()
     
     init(viewModel: StudyDetailViewModel) {
         self.viewModel = viewModel
@@ -124,13 +124,26 @@ final class StudyDetailViewController: ViewController {
         super.viewWillDisappear(animated)
         navigationController?.isNavigationBarHidden = true
     }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .mogakcoColor.backgroundDefault
+        navigationItem.leftBarButtonItem = UIBarButtonItem(customView: backButton)
+        layout()
+        bind()
+    }
     
-    override func layout() {
+    let backButton = UIButton().then {
+        $0.setTitle("이전", for: .normal)
+        $0.setTitleColor(.mogakcoColor.primaryDefault, for: .normal)
+    }
+    
+    func layout() {
         navigationLayout()
         layoutSubViews()
     }
     
-    override func bind() {
+    func bind() {
         let input = StudyDetailViewModel.Input(
             studyJoinButtonTapped: studyJoinButton.rx.tap.asObservable(),
             participantCellTapped: participantsCollectionView.rx.itemSelected.asObservable(),
@@ -159,7 +172,7 @@ final class StudyDetailViewController: ViewController {
             )) { _, hashtag, cell in
                 cell.setHashtag(hashtag: hashtag)
             }
-            .disposed(by: disposebag)
+            .disposed(by: disposeBag)
         
         output.participants
             .drive(participantsCollectionView.rx.items(
@@ -168,7 +181,7 @@ final class StudyDetailViewController: ViewController {
             )) { _, user, cell in
                 cell.setInfo(user: user)
             }
-            .disposed(by: disposebag)
+            .disposed(by: disposeBag)
     }
     
     private func navigationLayout() {
@@ -254,6 +267,7 @@ final class StudyDetailViewController: ViewController {
             $0.top.equalTo(participantsInfoLabel.snp.bottom).offset(10)
             $0.leading.trailing.equalToSuperview().inset(16)
             $0.height.equalTo(150)
+            $0.bottom.equalToSuperview()
         }
     }
     

--- a/Mogakco/Sources/Presentation/Study/ViewModel/StudyDetailViewModel.swift
+++ b/Mogakco/Sources/Presentation/Study/ViewModel/StudyDetailViewModel.swift
@@ -89,10 +89,12 @@ final class StudyDetailViewModel: ViewModel {
                 .map { (try? participants.value()[$0.0], $0.1) }
                 .withUnretained(self)
                 .subscribe {
+                    let user = $0.1.0
                     if $0.1.0?.id == $0.1.1.id {
                         $0.0.navigation.onNext(.profile(type: .current))
                     } else {
-                        $0.0.navigation.onNext(.profile(type: .other($0.1.1)))
+                        guard let other = $0.1.0 else { return }
+                        $0.0.navigation.onNext(.profile(type: .other(other)))
                     }
                 }
                 .disposed(by: disposeBag)


### PR DESCRIPTION
### PR Type

- [ ]  기능 추가 🔨
- [x]  버그 수정 🐞
- [x]  리팩토링 🚧
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [ ]  테스트 🔍
 

### Related Issue(작업 내용)

- close #357 
    - 로그인 애니메이션의 이미지가 Swift, Python, JavaScript, C++, Ruby로 고정되었습니다.
- close #358 
    - 채팅방 목록에서 채팅방으로 들어갈 때 Cell이 선택되어 배경이 하얗게 변하는 문제를 수정했습니다.
- close #359 
    - 스터디 상세에서 참여한 유저 CollectionView가 스크롤이나 터치 같은 상호작용이 불가능하던 버그를 수정했습니다.
- close #361 
    - 스터디 상세에서 유저의 설명이 소개에서 대표 언어로 바뀌었습니다.
    
### 참고 사항

- 유저 정보에서 표시되는 것이 대표 언어인 이유는 처음 언어를 선택할 때 첫 번째 언어가 대표 언어라고 공지되어 있어 선택했습니다. (+ 추가로 언어를 두 개 이상 보여주면 ...으로 표시되는 경우가 있습니다.)
- 스터디 상세에서 유저 정보로 이동하면 navigationBar가 보이지 않는 [이슈](https://github.com/boostcampwm-2022/iOS04-Mogakco/issues/375#issue-1481323358)가 있습니다. 탭바에서 들어갈 때와 구분이 필요해 보입니다.

### Screenshots(Optional)

<img src="https://user-images.githubusercontent.com/86254784/206126014-2b36f4dd-4680-4060-a585-1ac96163fa05.png" width="40%">

https://user-images.githubusercontent.com/86254784/206126352-0ab81e67-adce-4ef4-8051-c0abe189216a.mp4


