### PR TITLE
프로필 화면 세부 UI 조정

### DIFF
--- a/Mogakco/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Mogakco/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,1 +1,354 @@
-{"images":[{"size":"60x60","expected-size":"180","filename":"180.png","folder":"Assets.xcassets/AppIcon.appiconset/","idiom":"iphone","scale":"3x"},{"size":"40x40","expected-size":"80","filename":"80.png","folder":"Assets.xcassets/AppIcon.appiconset/","idiom":"iphone","scale":"2x"},{"size":"40x40","expected-size":"120","filename":"120.png","folder":"Assets.xcassets/AppIcon.appiconset/","idiom":"iphone","scale":"3x"},{"size":"60x60","expected-size":"120","filename":"120.png","folder":"Assets.xcassets/AppIcon.appiconset/","idiom":"iphone","scale":"2x"},{"size":"57x57","expected-size":"57","filename":"57.png","folder":"Assets.xcassets/AppIcon.appiconset/","idiom":"iphone","scale":"1x"},{"size":"29x29","expected-size":"58","filename":"58.png","folder":"Assets.xcassets/AppIcon.appiconset/","idiom":"iphone","scale":"2x"},{"size":"29x29","expected-size":"29","filename":"29.png","folder":"Assets.xcassets/AppIcon.appiconset/","idiom":"iphone","scale":"1x"},{"size":"29x29","expected-size":"87","filename":"87.png","folder":"Assets.xcassets/AppIcon.appiconset/","idiom":"iphone","scale":"3x"},{"size":"57x57","expected-size":"114","filename":"114.png","folder":"Assets.xcassets/AppIcon.appiconset/","idiom":"iphone","scale":"2x"},{"size":"20x20","expected-size":"40","filename":"40.png","folder":"Assets.xcassets/AppIcon.appiconset/","idiom":"iphone","scale":"2x"},{"size":"20x20","expected-size":"60","filename":"60.png","folder":"Assets.xcassets/AppIcon.appiconset/","idiom":"iphone","scale":"3x"},{"size":"1024x1024","filename":"1024.png","expected-size":"1024","idiom":"ios-marketing","folder":"Assets.xcassets/AppIcon.appiconset/","scale":"1x"},{"size":"40x40","expected-size":"80","filename":"80.png","folder":"Assets.xcassets/AppIcon.appiconset/","idiom":"ipad","scale":"2x"},{"size":"72x72","expected-size":"72","filename":"72.png","folder":"Assets.xcassets/AppIcon.appiconset/","idiom":"ipad","scale":"1x"},{"size":"76x76","expected-size":"152","filename":"152.png","folder":"Assets.xcassets/AppIcon.appiconset/","idiom":"ipad","scale":"2x"},{"size":"50x50","expected-size":"100","filename":"100.png","folder":"Assets.xcassets/AppIcon.appiconset/","idiom":"ipad","scale":"2x"},{"size":"29x29","expected-size":"58","filename":"58.png","folder":"Assets.xcassets/AppIcon.appiconset/","idiom":"ipad","scale":"2x"},{"size":"76x76","expected-size":"76","filename":"76.png","folder":"Assets.xcassets/AppIcon.appiconset/","idiom":"ipad","scale":"1x"},{"size":"29x29","expected-size":"29","filename":"29.png","folder":"Assets.xcassets/AppIcon.appiconset/","idiom":"ipad","scale":"1x"},{"size":"50x50","expected-size":"50","filename":"50.png","folder":"Assets.xcassets/AppIcon.appiconset/","idiom":"ipad","scale":"1x"},{"size":"72x72","expected-size":"144","filename":"144.png","folder":"Assets.xcassets/AppIcon.appiconset/","idiom":"ipad","scale":"2x"},{"size":"40x40","expected-size":"40","filename":"40.png","folder":"Assets.xcassets/AppIcon.appiconset/","idiom":"ipad","scale":"1x"},{"size":"83.5x83.5","expected-size":"167","filename":"167.png","folder":"Assets.xcassets/AppIcon.appiconset/","idiom":"ipad","scale":"2x"},{"size":"20x20","expected-size":"20","filename":"20.png","folder":"Assets.xcassets/AppIcon.appiconset/","idiom":"ipad","scale":"1x"},{"size":"20x20","expected-size":"40","filename":"40.png","folder":"Assets.xcassets/AppIcon.appiconset/","idiom":"ipad","scale":"2x"},{"idiom":"watch","filename":"172.png","folder":"Assets.xcassets/AppIcon.appiconset/","subtype":"38mm","scale":"2x","size":"86x86","expected-size":"172","role":"quickLook"},{"idiom":"watch","filename":"80.png","folder":"Assets.xcassets/AppIcon.appiconset/","subtype":"38mm","scale":"2x","size":"40x40","expected-size":"80","role":"appLauncher"},{"idiom":"watch","filename":"88.png","folder":"Assets.xcassets/AppIcon.appiconset/","subtype":"40mm","scale":"2x","size":"44x44","expected-size":"88","role":"appLauncher"},{"idiom":"watch","filename":"102.png","folder":"Assets.xcassets/AppIcon.appiconset/","subtype":"41mm","scale":"2x","size":"45x45","expected-size":"102","role":"appLauncher"},{"idiom":"watch","filename":"92.png","folder":"Assets.xcassets/AppIcon.appiconset/","subtype":"41mm","scale":"2x","size":"46x46","expected-size":"92","role":"appLauncher"},{"idiom":"watch","filename":"100.png","folder":"Assets.xcassets/AppIcon.appiconset/","subtype":"44mm","scale":"2x","size":"50x50","expected-size":"100","role":"appLauncher"},{"idiom":"watch","filename":"196.png","folder":"Assets.xcassets/AppIcon.appiconset/","subtype":"42mm","scale":"2x","size":"98x98","expected-size":"196","role":"quickLook"},{"idiom":"watch","filename":"216.png","folder":"Assets.xcassets/AppIcon.appiconset/","subtype":"44mm","scale":"2x","size":"108x108","expected-size":"216","role":"quickLook"},{"idiom":"watch","filename":"48.png","folder":"Assets.xcassets/AppIcon.appiconset/","subtype":"38mm","scale":"2x","size":"24x24","expected-size":"48","role":"notificationCenter"},{"idiom":"watch","filename":"55.png","folder":"Assets.xcassets/AppIcon.appiconset/","subtype":"42mm","scale":"2x","size":"27.5x27.5","expected-size":"55","role":"notificationCenter"},{"idiom":"watch","filename":"66.png","folder":"Assets.xcassets/AppIcon.appiconset/","subtype":"45mm","scale":"2x","size":"33x33","expected-size":"66","role":"notificationCenter"},{"size":"29x29","expected-size":"87","filename":"87.png","folder":"Assets.xcassets/AppIcon.appiconset/","idiom":"watch","role":"companionSettings","scale":"3x"},{"size":"29x29","expected-size":"58","filename":"58.png","folder":"Assets.xcassets/AppIcon.appiconset/","idiom":"watch","role":"companionSettings","scale":"2x"},{"size":"1024x1024","expected-size":"1024","filename":"1024.png","folder":"Assets.xcassets/AppIcon.appiconset/","idiom":"watch-marketing","scale":"1x"},{"size":"128x128","expected-size":"128","filename":"128.png","folder":"Assets.xcassets/AppIcon.appiconset/","idiom":"mac","scale":"1x"},{"size":"256x256","expected-size":"256","filename":"256.png","folder":"Assets.xcassets/AppIcon.appiconset/","idiom":"mac","scale":"1x"},{"size":"128x128","expected-size":"256","filename":"256.png","folder":"Assets.xcassets/AppIcon.appiconset/","idiom":"mac","scale":"2x"},{"size":"256x256","expected-size":"512","filename":"512.png","folder":"Assets.xcassets/AppIcon.appiconset/","idiom":"mac","scale":"2x"},{"size":"32x32","expected-size":"32","filename":"32.png","folder":"Assets.xcassets/AppIcon.appiconset/","idiom":"mac","scale":"1x"},{"size":"512x512","expected-size":"512","filename":"512.png","folder":"Assets.xcassets/AppIcon.appiconset/","idiom":"mac","scale":"1x"},{"size":"16x16","expected-size":"16","filename":"16.png","folder":"Assets.xcassets/AppIcon.appiconset/","idiom":"mac","scale":"1x"},{"size":"16x16","expected-size":"32","filename":"32.png","folder":"Assets.xcassets/AppIcon.appiconset/","idiom":"mac","scale":"2x"},{"size":"32x32","expected-size":"64","filename":"64.png","folder":"Assets.xcassets/AppIcon.appiconset/","idiom":"mac","scale":"2x"},{"size":"512x512","expected-size":"1024","filename":"1024.png","folder":"Assets.xcassets/AppIcon.appiconset/","idiom":"mac","scale":"2x"}]}
+{
+  "images" : [
+    {
+      "filename" : "40.png",
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "filename" : "60.png",
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "20x20"
+    },
+    {
+      "filename" : "29.png",
+      "idiom" : "iphone",
+      "scale" : "1x",
+      "size" : "29x29"
+    },
+    {
+      "filename" : "58.png",
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "filename" : "87.png",
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "29x29"
+    },
+    {
+      "filename" : "80.png",
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "filename" : "120.png",
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "40x40"
+    },
+    {
+      "filename" : "57.png",
+      "idiom" : "iphone",
+      "scale" : "1x",
+      "size" : "57x57"
+    },
+    {
+      "filename" : "114.png",
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "57x57"
+    },
+    {
+      "filename" : "120.png",
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "60x60"
+    },
+    {
+      "filename" : "180.png",
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "60x60"
+    },
+    {
+      "filename" : "20.png",
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "20x20"
+    },
+    {
+      "filename" : "40.png",
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "filename" : "29.png",
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "29x29"
+    },
+    {
+      "filename" : "58.png",
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "filename" : "40.png",
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "40x40"
+    },
+    {
+      "filename" : "80.png",
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "filename" : "50.png",
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "50x50"
+    },
+    {
+      "filename" : "100.png",
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "50x50"
+    },
+    {
+      "filename" : "72.png",
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "72x72"
+    },
+    {
+      "filename" : "144.png",
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "72x72"
+    },
+    {
+      "filename" : "76.png",
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "76x76"
+    },
+    {
+      "filename" : "152.png",
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "76x76"
+    },
+    {
+      "filename" : "167.png",
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "83.5x83.5"
+    },
+    {
+      "filename" : "1024.png",
+      "idiom" : "ios-marketing",
+      "scale" : "1x",
+      "size" : "1024x1024"
+    },
+    {
+      "filename" : "16.png",
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "16x16"
+    },
+    {
+      "filename" : "32.png",
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "16x16"
+    },
+    {
+      "filename" : "32.png",
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "32x32"
+    },
+    {
+      "filename" : "64.png",
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "32x32"
+    },
+    {
+      "filename" : "128.png",
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "128x128"
+    },
+    {
+      "filename" : "256.png",
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "128x128"
+    },
+    {
+      "filename" : "256.png",
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "256x256"
+    },
+    {
+      "filename" : "512.png",
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "256x256"
+    },
+    {
+      "filename" : "512.png",
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "512x512"
+    },
+    {
+      "filename" : "1024.png",
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "512x512"
+    },
+    {
+      "filename" : "48.png",
+      "idiom" : "watch",
+      "role" : "notificationCenter",
+      "scale" : "2x",
+      "size" : "24x24",
+      "subtype" : "38mm"
+    },
+    {
+      "filename" : "55.png",
+      "idiom" : "watch",
+      "role" : "notificationCenter",
+      "scale" : "2x",
+      "size" : "27.5x27.5",
+      "subtype" : "42mm"
+    },
+    {
+      "filename" : "58.png",
+      "idiom" : "watch",
+      "role" : "companionSettings",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "filename" : "87.png",
+      "idiom" : "watch",
+      "role" : "companionSettings",
+      "scale" : "3x",
+      "size" : "29x29"
+    },
+    {
+      "filename" : "66.png",
+      "idiom" : "watch",
+      "role" : "notificationCenter",
+      "scale" : "2x",
+      "size" : "33x33",
+      "subtype" : "45mm"
+    },
+    {
+      "filename" : "80.png",
+      "idiom" : "watch",
+      "role" : "appLauncher",
+      "scale" : "2x",
+      "size" : "40x40",
+      "subtype" : "38mm"
+    },
+    {
+      "filename" : "88.png",
+      "idiom" : "watch",
+      "role" : "appLauncher",
+      "scale" : "2x",
+      "size" : "44x44",
+      "subtype" : "40mm"
+    },
+    {
+      "filename" : "92.png",
+      "idiom" : "watch",
+      "role" : "appLauncher",
+      "scale" : "2x",
+      "size" : "46x46",
+      "subtype" : "41mm"
+    },
+    {
+      "filename" : "100.png",
+      "idiom" : "watch",
+      "role" : "appLauncher",
+      "scale" : "2x",
+      "size" : "50x50",
+      "subtype" : "44mm"
+    },
+    {
+      "idiom" : "watch",
+      "role" : "appLauncher",
+      "scale" : "2x",
+      "size" : "51x51",
+      "subtype" : "45mm"
+    },
+    {
+      "idiom" : "watch",
+      "role" : "appLauncher",
+      "scale" : "2x",
+      "size" : "54x54",
+      "subtype" : "49mm"
+    },
+    {
+      "filename" : "172.png",
+      "idiom" : "watch",
+      "role" : "quickLook",
+      "scale" : "2x",
+      "size" : "86x86",
+      "subtype" : "38mm"
+    },
+    {
+      "filename" : "196.png",
+      "idiom" : "watch",
+      "role" : "quickLook",
+      "scale" : "2x",
+      "size" : "98x98",
+      "subtype" : "42mm"
+    },
+    {
+      "filename" : "216.png",
+      "idiom" : "watch",
+      "role" : "quickLook",
+      "scale" : "2x",
+      "size" : "108x108",
+      "subtype" : "44mm"
+    },
+    {
+      "idiom" : "watch",
+      "role" : "quickLook",
+      "scale" : "2x",
+      "size" : "117x117",
+      "subtype" : "45mm"
+    },
+    {
+      "idiom" : "watch",
+      "role" : "quickLook",
+      "scale" : "2x",
+      "size" : "129x129",
+      "subtype" : "49mm"
+    },
+    {
+      "filename" : "1024.png",
+      "idiom" : "watch-marketing",
+      "scale" : "1x",
+      "size" : "1024x1024"
+    },
+    {
+      "filename" : "102.png",
+      "idiom" : "watch",
+      "role" : "appLauncher",
+      "scale" : "2x",
+      "size" : "45x45",
+      "subtype" : "41mm"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Mogakco/Resources/Assets.xcassets/Colors/gradientEnd.colorset/Contents.json
+++ b/Mogakco/Resources/Assets.xcassets/Colors/gradientEnd.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x28",
+          "green" : "0x37",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x28",
+          "green" : "0x37",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Mogakco/Resources/Assets.xcassets/Colors/gradientStart.colorset/Contents.json
+++ b/Mogakco/Resources/Assets.xcassets/Colors/gradientStart.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x41",
+          "green" : "0xAA",
+          "red" : "0xF9"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x41",
+          "green" : "0xAA",
+          "red" : "0xF9"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Mogakco/Sources/Presentation/Profile/View/HashtagListView.swift
+++ b/Mogakco/Sources/Presentation/Profile/View/HashtagListView.swift
@@ -29,7 +29,6 @@ final class HashtagListView: UIView {
         $0.setTitle("편집", for: .normal)
         $0.setTitleColor(UIColor.mogakcoColor.typographyPrimary, for: .normal)
         $0.titleLabel?.font = UIFont.mogakcoFont.caption
-        $0.setBackgroundColor(UIColor.mogakcoColor.primarySecondary ?? UIColor.white, for: .normal)
         $0.titleLabel?.textAlignment = .center
         $0.snp.makeConstraints {
             $0.size.equalTo(Constant.editButtonSize)
@@ -40,7 +39,8 @@ final class HashtagListView: UIView {
         frame: .zero,
         collectionViewLayout: UICollectionViewFlowLayout()).then {
         let layout = UICollectionViewFlowLayout()
-        layout.estimatedItemSize = UICollectionViewFlowLayout.automaticSize
+        layout.estimatedItemSize = CGSize(width: HashtagBadgeCell.addWidth, height: HashtagBadgeCell.height)
+        layout.itemSize = UICollectionViewFlowLayout.automaticSize
         layout.sectionInset = UIEdgeInsets(top: 0.0, left: 8.0, bottom: 0.0, right: 8.0)
 
         $0.collectionViewLayout = layout
@@ -49,8 +49,6 @@ final class HashtagListView: UIView {
         $0.bounces = false
         layout.scrollDirection = .horizontal
         $0.isPagingEnabled = false
-            $0.dataSource = nil
-            $0.delegate = nil
     }
     
     private let emptyLabel = UILabel().then {
@@ -83,7 +81,7 @@ final class HashtagListView: UIView {
                 return cell
             }
             .disposed(by: disposeBag)
-        
+
         hashtags
             .map { !$0.isEmpty }
             .drive(emptyLabel.rx.isHidden)

--- a/Mogakco/Sources/Presentation/Profile/View/ProfileView.swift
+++ b/Mogakco/Sources/Presentation/Profile/View/ProfileView.swift
@@ -21,17 +21,16 @@ final class ProfileView: UIView {
         $0.snp.makeConstraints {
             $0.size.equalTo(45.0)
         }
-        $0.setPhoto(MogakcoAsset.swift.image)
     }
     
     let nameLabel = UILabel().then {
-        $0.font = UIFont.mogakcoFont.smallBold
+        $0.font = UIFont.mogakcoFont.mediumBold
         $0.textColor = .mogakcoColor.typographyPrimary
         $0.textAlignment = .left
     }
     
     let introduceLabel = UILabel().then {
-        $0.font = UIFont.mogakcoFont.caption
+        $0.font = UIFont.mogakcoFont.smallBold
         $0.textColor = .mogakcoColor.typographySecondary
         $0.numberOfLines = 0
         $0.textAlignment = .left
@@ -39,7 +38,7 @@ final class ProfileView: UIView {
     
     let chatButton = UIButton().then {
         $0.clipsToBounds = true
-        $0.layer.cornerRadius = 12.0
+        $0.layer.cornerRadius = 10.0
         $0.setTitle("채팅", for: .normal)
         $0.setTitleColor(UIColor.mogakcoColor.typographyPrimary, for: .normal)
         $0.titleLabel?.font = UIFont.mogakcoFont.smallBold
@@ -48,7 +47,7 @@ final class ProfileView: UIView {
     
     let editProfileButton = UIButton().then {
         $0.clipsToBounds = true
-        $0.layer.cornerRadius = 14.0
+        $0.layer.cornerRadius = 10.0
         $0.setTitle("프로필 편집", for: .normal)
         $0.setTitleColor(UIColor.mogakcoColor.typographyPrimary, for: .normal)
         $0.titleLabel?.font = UIFont.mogakcoFont.smallBold
@@ -57,7 +56,7 @@ final class ProfileView: UIView {
     
     let reportButton = UIButton().then {
         $0.clipsToBounds = true
-        $0.layer.cornerRadius = 12.0
+        $0.layer.cornerRadius = 10.0
         $0.setTitle("차단", for: .normal)
         $0.setTitleColor(UIColor.mogakcoColor.typographyPrimary, for: .normal)
         $0.titleLabel?.font = UIFont.mogakcoFont.smallBold
@@ -124,6 +123,11 @@ final class ProfileView: UIView {
     
     private func createButtonStackView() -> UIStackView {
         let arrangeSubviews = [reportButton, chatButton, editProfileButton]
+        arrangeSubviews.forEach {
+            $0.snp.makeConstraints {
+                $0.height.equalTo(48.0)
+            }
+        }
         return UIStackView(arrangedSubviews: arrangeSubviews).then {
             $0.axis = .horizontal
             $0.spacing = 16.0

--- a/Mogakco/Sources/Presentation/Profile/View/StudyRatingListView.swift
+++ b/Mogakco/Sources/Presentation/Profile/View/StudyRatingListView.swift
@@ -14,7 +14,7 @@ class StudyRatingListView: UIView {
     enum Constant {
         static let studyRatingListTitle = "스터디 참여 Top3"
         static let emptyText = "아직 참여한 스터디가 없어요"
-        static let studyRatingViewHeight = 40.0
+        static let studyRatingViewHeight = 50.0
     }
     
     private let titleLabel = UILabel().then {
@@ -76,14 +76,14 @@ class StudyRatingListView: UIView {
     }
 
     private func layout() {
-        let stackView = makeEntireStackView()
+        let stackView = createEntireStackView()
         addSubview(stackView)
         stackView.snp.makeConstraints {
             $0.edges.equalToSuperview()
         }
     }
     
-    private func makeEntireStackView() -> UIStackView {
+    private func createEntireStackView() -> UIStackView {
         let arrangeViews = [
             titleLabel,
             firstStudyRatingView,

--- a/Mogakco/Sources/Presentation/Profile/View/StudyRatingView.swift
+++ b/Mogakco/Sources/Presentation/Profile/View/StudyRatingView.swift
@@ -28,13 +28,23 @@ class StudyRatingView: UIView {
 
     override init(frame: CGRect) {
         super.init(frame: frame)
-        attribute()
         layout()
+        attribute()
     }
 
     @available(*, unavailable)
     required init?(coder _: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        setGradient(
+            startColor: .mogakcoColor.gradientStart?.withAlphaComponent(0.45) ?? .systemGray,
+            endColor: .mogakcoColor.gradientEnd?.withAlphaComponent(0.45) ?? .systemGray,
+            startPoint: .init(x: 0.0, y: 0.5),
+            endPoint: .init(x: 1.0, y: 0.5)
+        )
     }
     
     func configure(studyRating: (String, Int)) {
@@ -49,21 +59,23 @@ class StudyRatingView: UIView {
     }
 
     private func layout() {
-        let stackView = makeEntireStackView()
+        let stackView = createEntireStackView()
         addSubview(stackView)
         stackView.snp.makeConstraints {
             $0.edges.equalToSuperview()
         }
     }
     
-    private func makeEntireStackView() -> UIStackView {
+    private func createEntireStackView() -> UIStackView {
         let arrangeSubviews = [iconImageView, contentLabel, countLabel]
         iconImageView.snp.makeConstraints {
             $0.width.equalTo(iconImageView.snp.height)
         }
         return UIStackView(arrangedSubviews: arrangeSubviews).then {
+            $0.isLayoutMarginsRelativeArrangement = true
+            $0.layoutMargins = .init(top: 0.0, left: 12.0, bottom: 0.0, right: 12.0)
             $0.axis = .horizontal
-            $0.spacing = 4.0
+            $0.spacing = 12.0
         }
     }
 }

--- a/Mogakco/Sources/Presentation/Profile/ViewController/ProfileViewController.swift
+++ b/Mogakco/Sources/Presentation/Profile/ViewController/ProfileViewController.swift
@@ -20,8 +20,8 @@ final class ProfileViewController: ViewController {
         static let categoryHashtagListViewTitle = "카테고리"
         static let headerViewHeight = 68.0
         static let profileViewHeight = 200.0
-        static let hashtagViewHeight = 100.0
         static let studyRatingListView = 200.0
+        static let hashtagViewHeight = 80.0
         static let bottomMarginViewHeight = 60.0
     }
     

--- a/Mogakco/Sources/Presentation/Profile/ViewController/ProfileViewController.swift
+++ b/Mogakco/Sources/Presentation/Profile/ViewController/ProfileViewController.swift
@@ -11,7 +11,7 @@ import UIKit
 import RxSwift
 import SnapKit
 
-final class ProfileViewController: ViewController {
+final class ProfileViewController: UIViewController {
 
     enum Constant {
         static let headerViewTitle = "프로필"
@@ -20,8 +20,8 @@ final class ProfileViewController: ViewController {
         static let categoryHashtagListViewTitle = "카테고리"
         static let headerViewHeight = 68.0
         static let profileViewHeight = 200.0
-        static let studyRatingListView = 200.0
         static let hashtagViewHeight = 80.0
+        static let studyRatingListView = 230.0
         static let bottomMarginViewHeight = 60.0
     }
     
@@ -32,14 +32,16 @@ final class ProfileViewController: ViewController {
     
     private lazy var contentStackView = UIStackView(arrangedSubviews: [
         self.profileView,
+        self.boundaryView,
         self.languageListView,
         self.careerListView,
         self.categoryListView,
         self.studyRatingListView,
         self.bottomMarginView
     ]).then {
-        $0.spacing = 4.0
+        $0.spacing = 8.0
         $0.axis = .vertical
+        $0.setCustomSpacing(12.0, after: self.boundaryView)
     }
     
     private let headerView = TitleHeaderView().then {
@@ -49,6 +51,13 @@ final class ProfileViewController: ViewController {
     private let profileView = ProfileView().then {
         $0.snp.makeConstraints {
             $0.height.equalTo(Constant.profileViewHeight)
+        }
+    }
+    
+    private let boundaryView = UIView().then {
+        $0.backgroundColor = .mogakcoColor.primaryDefault
+        $0.snp.makeConstraints {
+            $0.height.equalTo(4.0) 
         }
     }
     
@@ -91,12 +100,14 @@ final class ProfileViewController: ViewController {
     }
 
     private let report = PublishSubject<Void>()
-    
+    private let disposeBag = DisposeBag()
     private var viewModel: ProfileViewModel
     
     init(viewModel: ProfileViewModel) {
         self.viewModel = viewModel
         super.init(nibName: nil, bundle: nil)
+        bind()
+        layout()
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -113,7 +124,7 @@ final class ProfileViewController: ViewController {
         fatalError("init(coder:) has not been implemented")
     }
     
-    override func bind() {
+    func bind() {
         let input = ProfileViewModel.Input(
             viewWillAppear: rx.viewWillAppear.map { _ in }.asObservable(),
             editProfileButtonTapped: profileView.editProfileButton.rx.tap.asObservable(),
@@ -134,7 +145,7 @@ final class ProfileViewController: ViewController {
         bindReportButton()
     }
     
-    private func bindIsMyProfile(output: ProfileViewModel.Output) {
+    func bindIsMyProfile(output: ProfileViewModel.Output) {
         output.isMyProfile
             .drive(profileView.chatButton.rx.isHidden)
             .disposed(by: disposeBag)
@@ -217,7 +228,7 @@ final class ProfileViewController: ViewController {
             .disposed(by: disposeBag)
     }
     
-    override func layout() {
+    func layout() {
         layoutHeaderView()
         layoutScrollView()
         layoutSettingButton()

--- a/Mogakco/Sources/Util/Extension/UIColor+MogakcoColor.swift
+++ b/Mogakco/Sources/Util/Extension/UIColor+MogakcoColor.swift
@@ -32,4 +32,8 @@ struct MogakcoColor {
     
     // Background
     let backgroundDefault = UIColor(named: "BackgroundDefault")
+    
+    // Gradient
+    let gradientStart = UIColor(named: "gradientStart")
+    let gradientEnd = UIColor(named: "gradientEnd")
 }

--- a/Mogakco/Sources/Util/Extension/UIView+Gradient.swift
+++ b/Mogakco/Sources/Util/Extension/UIView+Gradient.swift
@@ -1,0 +1,21 @@
+//
+//  UIView+Gradient.swift
+//  Mogakco
+//
+//  Created by 김범수 on 2022/12/07.
+//  Copyright © 2022 Mogakco. All rights reserved.
+//
+
+import UIKit
+
+extension UIView {
+    func setGradient(startColor: UIColor, endColor: UIColor, startPoint: CGPoint, endPoint: CGPoint) {
+        let gradient = CAGradientLayer()
+        gradient.colors = [startColor.cgColor, endColor.cgColor]
+        gradient.locations = [0.0, 1.0]
+        gradient.startPoint = startPoint
+        gradient.endPoint = endPoint
+        gradient.frame = bounds
+        layer.insertSublayer(gradient, at: 0)
+    }
+}


### PR DESCRIPTION
### PR Type

- [x]  기능 추가 🔨
- [ ]  버그 수정 🐞
- [ ]  리팩토링 🚧
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [x]  기타 사소한 수정 🎸
- [ ]  테스트 🔍
 

### Related Issue(작업 내용)

- resolve #247 
    - 프로필 해시태그 크기 조정
    - 프로필 스터디 Top3 Gradient 효과
    - 프로필 세부 UI 조정

### 참고 사항
UIView Extension의 setGradient 메소드를 추가하였습니다
아래처럼 입력 인자를 주면 스크린샷과 같은 효과가 가능하여 추가적으로 이용 시 프로토콜화 시켜놔도 좋을 듯 하네요!
``` swift
  setGradient(
      startColor: .mogakcoColor.gradientStart?.withAlphaComponent(0.45) ?? .systemGray,
      endColor: .mogakcoColor.gradientEnd?.withAlphaComponent(0.45) ?? .systemGray,
      startPoint: .init(x: 0.0, y: 0.5),
      endPoint: .init(x: 1.0, y: 0.5)
  )
```



### Screenshots(Optional)
<img src="https://user-images.githubusercontent.com/73675540/206148589-a0da3628-dceb-4d0c-ab79-063cbd501f4f.png" width="50%">
