### PR TITLE
채팅 프로필 선택 시 유저 상세 화면 이동

### DIFF
--- a/Mogakco/Sources/Presentation/Chat/View/ChatCell.swift
+++ b/Mogakco/Sources/Presentation/Chat/View/ChatCell.swift
@@ -15,6 +15,8 @@ final class ChatCell: UICollectionViewCell, Identifiable {
     
     private let profileImageView = RoundProfileImageView(35)
     
+    let profileImageButton = UIButton()
+    
     let textView = UITextView().then {
         $0.backgroundColor = .clear
         $0.font = UIFont.mogakcoFont.smallBold
@@ -48,6 +50,7 @@ final class ChatCell: UICollectionViewCell, Identifiable {
     private func layout() {
         layoutCell()
         layoutProfileImageView()
+        layoutProfileImageButton()
         layoutBubbleContainerView()
         layoutTextView()
     }
@@ -62,6 +65,14 @@ final class ChatCell: UICollectionViewCell, Identifiable {
         profileImageView.snp.makeConstraints {
             $0.left.equalToSuperview().offset(12)
             $0.top.equalToSuperview().offset(4)
+        }
+    }
+    
+    private func layoutProfileImageButton() {
+        addSubview(profileImageButton)
+        
+        profileImageButton.snp.makeConstraints {
+            $0.edges.equalTo(profileImageView)
         }
     }
     

--- a/Mogakco/Sources/Presentation/Chat/ViewController/ChatViewController.swift
+++ b/Mogakco/Sources/Presentation/Chat/ViewController/ChatViewController.swift
@@ -140,13 +140,19 @@ final class ChatViewController: ViewController {
         
         viewModel.messages
             .asDriver(onErrorJustReturn: [])
-            .drive(collectionView.rx.items) { collectionView, index, chat in
-                guard let cell = collectionView.dequeueReusableCell(
+            .drive(collectionView.rx.items) { [weak self] collectionView, index, chat in
+                guard let self = self,
+                      let cell = collectionView.dequeueReusableCell(
                     withReuseIdentifier: ChatCell.identifier,
                     for: IndexPath(row: index, section: 0)) as? ChatCell else {
                     return UICollectionViewCell()
                 }
                 cell.layoutChat(chat: chat)
+                
+                cell.profileImageButton.rx.tap
+                    .compactMap { chat.user }
+                    .bind(to: selectedUser)
+                    .disposed(by: self.disposeBag)
                 return cell
             }
             .disposed(by: disposeBag)

--- a/Mogakco/Sources/Presentation/Chat/ViewModel/ChatViewModel.swift
+++ b/Mogakco/Sources/Presentation/Chat/ViewModel/ChatViewModel.swift
@@ -30,6 +30,7 @@ final class ChatViewModel: ViewModel {
         let sendButtonDidTap: Observable<Void>
         let inputViewText: Observable<String>
         let pagination: Observable<Void>?
+        let selectedUser: Observable<User>
     }
     
     struct Output {
@@ -141,6 +142,11 @@ final class ChatViewModel: ViewModel {
                     })
                     .disposed(by: self.disposeBag)
             }
+            .disposed(by: disposeBag)
+        
+        input.selectedUser
+            .map { .profile(type: .other($0)) }
+            .bind(to: navigation)
             .disposed(by: disposeBag)
         
         return Output(

--- a/Mogakco/Sources/Presentation/Chat/ViewModel/ChatViewModel.swift
+++ b/Mogakco/Sources/Presentation/Chat/ViewModel/ChatViewModel.swift
@@ -34,11 +34,13 @@ final class ChatViewModel: ViewModel {
     }
     
     struct Output {
-        let showChatSidebarView: Observable<Void>
-        let selectedSidebar: Observable<ChatSidebarMenu>
-        let inputViewText: Observable<String>
-        let sendMessage: Observable<Void>
-        let refreshFinished: Observable<Void>
+        let messages: Driver<[Chat]>
+        let chatSidebarMenus: Driver<[ChatSidebarMenu]>
+        let showChatSidebarView: Signal<Void>
+        let selectedSidebar: Signal<ChatSidebarMenu>
+        let inputViewText: Driver<String>
+        let sendMessageCompleted: Driver<Void>
+        let refreshFinished: Signal<Void>
     }
     
     private var isFirst = true
@@ -48,117 +50,131 @@ final class ChatViewModel: ViewModel {
     var subscribePushNotificationUseCase: SubscribePushNotificationUseCaseProtocol?
     var unsubscribePushNotificationUseCase: UnsubscribePushNotificationUseCaseProtocol?
     private var chatArray: [Chat] = []
-    var messages = BehaviorRelay<[Chat]>(value: [])
+    let messages = BehaviorRelay<[Chat]>(value: [])
     let navigation = PublishSubject<ChatRoomNavigation>()
     var disposeBag = DisposeBag()
+    
+    private let selectedSidebar = PublishSubject<ChatSidebarMenu>()
+    private let inputViewText = PublishSubject<String>()
+    private let sendMessageCompleted = PublishSubject<Void>()
+    private let studyInfoTap = PublishSubject<Void>()
+    private let exitStudyTap = PublishSubject<Void>()
+    private let showMemberTap = PublishSubject<Void>()
+    private let refreshFinished = PublishSubject<Void>()
 
     func transform(input: Input) -> Output {
-        let showChatSidebarView = PublishSubject<Void>()
-        let selectedSidebar = PublishSubject<ChatSidebarMenu>()
-        let inputViewText = PublishSubject<String>()
-        let sendMessage = PublishSubject<Void>()
-        let studyInfoTap = PublishSubject<Void>()
-        let exitStudyTap = PublishSubject<Void>()
-        let showMemberTap = PublishSubject<Void>()
-        let refreshFinished = PublishSubject<Void>()
+        bindChats(input: input)
+        bindSideBar(input: input)
+		bindPushNotification(input: input)
+        bindScene(input: input)
+
+        return Output(
+            messages: messages.asDriver(onErrorJustReturn: []),
+            chatSidebarMenus: Driver<[ChatSidebarMenu]>.just(ChatSidebarMenu.allCases),
+            showChatSidebarView: input.studyInfoButtonDidTap.asObservable().asSignal(onErrorSignalWith: .empty()),
+            selectedSidebar: selectedSidebar.asSignal(onErrorSignalWith: .empty()),
+            inputViewText: inputViewText.asDriver(onErrorJustReturn: ""),
+            sendMessageCompleted: sendMessageCompleted.asDriver(onErrorJustReturn: ()),
+            refreshFinished: refreshFinished.asSignal(onErrorSignalWith: .empty())
+        )
+    }
+    
+    private func bindChats(input: Input) {
+        // 채팅 로드
         
-        bindPushNotification(input: input)
-        
-        observeFirebase()
-        fetchChats()
-        backButtonDidTap(input: input)
-        
-        input.pagination?
-            .subscribe({ [weak self] _ in
-                guard let self = self else { return }
-                self.fetchChats()
-                refreshFinished.onNext(())
-            })
-            .disposed(by: disposeBag)
-        
-        input.studyInfoButtonDidTap
-            .subscribe(onNext: {
-                showChatSidebarView.onNext(())
-            })
-            .disposed(by: disposeBag)
-        
-        input.selectedSidebar
-            .map { ChatSidebarMenu(row: $0.row) }
-            .subscribe { row in
-                switch row {
-                case .studyInfo: studyInfoTap.onNext(())
-                case .exitStudy: exitStudyTap.onNext(())
-                case .showMember: showMemberTap.onNext(())
-                }
-            }
-            .disposed(by: disposeBag)
-        
-        studyInfoTap
-            .subscribe(onNext: {
-                selectedSidebar.onNext(.studyInfo)
-            })
-            .disposed(by: disposeBag)
-        
-        exitStudyTap
+        Observable.merge(
+            Observable.just(()),
+            input.pagination ?? .empty()
+        )
             .withUnretained(self)
-            .flatMap { $0.0.leaveStudyUseCase?.leaveStudy(id: $0.0.chatRoomID) ?? .empty() }
-            .subscribe {
-                selectedSidebar.onNext(.exitStudy)
-            } onError: { error in
-                print(self.chatRoomID)
-                print(error)
-            }
-            .disposed(by: disposeBag)
-        
-        showMemberTap
-            .subscribe(onNext: {
-                selectedSidebar.onNext(.showMember)
+            .flatMap { $0.0.chatUseCase?.fetch(chatRoomID: $0.0.chatRoomID) ?? .empty() }
+            .withLatestFrom(messages) { ($0, $1) }
+            .subscribe(onNext: { [weak self] newChat, originalChat in
+                self?.messages.accept(newChat + originalChat)
+                self?.sendMessageCompleted.onNext(())
             })
             .disposed(by: disposeBag)
+        
+        // 채팅 observe
+        
+        chatUseCase?.observe(chatRoomID: chatRoomID)
+            .withLatestFrom(messages) { ($0, $1) }
+            .subscribe(onNext: { [weak self] newChat, originalChats in
+                if self?.isFirst == false {
+                    print("self?.isFirst : ", newChat, originalChats)
+                    self?.messages.accept(originalChats + [newChat])
+                } else {
+                    self?.isFirst = false
+                }
+            })
+            .disposed(by: disposeBag)
+        
+        // 채팅 전송
         
         input.sendButtonDidTap
             .withLatestFrom(Observable.combineLatest(
                 chatUseCase?.myProfile() ?? .empty(),
                 input.inputViewText
             )) { ( $1.0, $1.1 ) }
-            .subscribe { [weak self] user, message in
-                guard let self = self else { return }
-
-                self.chatUseCase?
-                    .send(
-                        chat: Chat(
-                            id: UUID().uuidString,
-                            userID: user.id,
-                            message: message,
-                            chatRoomID: self.chatRoomID,
-                            date: Date().toInt(dateFormat: Format.chatDateFormat),
-                            readUserIDs: [user.id],
-                            user: user
-                        ),
-                        to: self.chatRoomID
-                    )
-                    .subscribe(onNext: { _ in
-                        sendMessage.onNext(())
-                    })
-                    .disposed(by: self.disposeBag)
+            .map { user, message -> Chat in
+                return Chat(
+                    id: UUID().uuidString,
+                    userID: user.id,
+                    message: message,
+                    chatRoomID: self.chatRoomID,
+                    date: Date().toInt(dateFormat: Format.chatDateFormat),
+                    readUserIDs: [user.id]
+                )
             }
+            .withUnretained(self)
+            .flatMap { viewModel, chat in
+                viewModel.chatUseCase?.send(chat: chat, to: viewModel.chatRoomID) ?? .empty()
+            }
+            .subscribe(onNext: { [weak self] in
+                self?.sendMessageCompleted.onNext(())
+            }, onError: {
+                print("메세지 전송 실패 \($0)")
+            })
             .disposed(by: disposeBag)
-        
-        input.selectedUser
-            .map { .profile(type: .other($0)) }
-            .bind(to: navigation)
-            .disposed(by: disposeBag)
-        
-        return Output(
-            showChatSidebarView: showChatSidebarView,
-            selectedSidebar: selectedSidebar,
-            inputViewText: inputViewText,
-            sendMessage: sendMessage,
-            refreshFinished: refreshFinished
-        )
     }
     
-    private func bindPushNotification(input: Input) {
+    private func bindSideBar(input: Input) {
+        input.selectedSidebar
+            .map { ChatSidebarMenu(row: $0.row) }
+            .withUnretained(self)
+            .subscribe(onNext: { viewModel, row in
+                switch row {
+                case .studyInfo: viewModel.studyInfoTap.onNext(())
+                case .exitStudy: viewModel.exitStudyTap.onNext(())
+                case .showMember: viewModel.showMemberTap.onNext(())
+                }
+            })
+            .disposed(by: disposeBag)
+        
+        studyInfoTap
+            .subscribe(onNext: { [weak self] in
+                self?.selectedSidebar.onNext(.studyInfo)
+            })
+            .disposed(by: disposeBag)
+        
+        exitStudyTap
+            .withUnretained(self)
+            .flatMap { $0.0.leaveStudyUseCase?.leaveStudy(id: $0.0.chatRoomID) ?? .empty() }
+            .subscribe(onNext: { [weak self] in
+                self?.selectedSidebar.onNext(.exitStudy)
+            }, onError: { error in
+                print(error)
+            })
+            .disposed(by: disposeBag)
+        
+        showMemberTap
+            .subscribe(onNext: { [weak self] in
+                self?.selectedSidebar.onNext(.showMember)
+            })
+            .disposed(by: disposeBag)
+    }
+
+ 	private func bindPushNotification(input: Input) {
         // 채팅방 들어올 시 -> 푸쉬 알림 구독 해제
         Observable.merge(
             input.viewWillAppear,
@@ -181,33 +197,16 @@ final class ChatViewModel: ViewModel {
         })
         .disposed(by: disposeBag)
     }
+
     
-    private func observeFirebase() {
-        chatUseCase?.observe(chatRoomID: chatRoomID)
-            .withLatestFrom(messages) { ($0, $1) }
-            .subscribe(onNext: { [weak self] newChat, originalChats in
-                if self?.isFirst == false {
-                    print("self?.isFirst : ", newChat, originalChats)
-                    self?.messages.accept( originalChats + [newChat])
-                } else {
-                    self?.isFirst = false
-                }
-            })
-            .disposed(by: disposeBag)
-    }
-    
-    private func fetchChats() {
-        chatUseCase?.fetch(chatRoomID: chatRoomID)
-            .withLatestFrom(messages) { ($0, $1) }
-            .subscribe(onNext: { [weak self] newChat, originalChat in
-                self?.messages.accept(newChat + originalChat)
-            })
-            .disposed(by: disposeBag)
-    }
-    
-    private func backButtonDidTap(input: Input) {
+    private func bindScene(input: Input) {
         input.backButtonDidTap
             .map { ChatRoomNavigation.back }
+            .bind(to: navigation)
+            .disposed(by: disposeBag)
+        
+        input.selectedUser
+            .map { .profile(type: .other($0)) }
             .bind(to: navigation)
             .disposed(by: disposeBag)
     }

--- a/Mogakco/Sources/Util/Extension/UINavigation+Swipe.swift
+++ b/Mogakco/Sources/Util/Extension/UINavigation+Swipe.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-extension UINavigationController: ObservableObject, UIGestureRecognizerDelegate {
+extension UINavigationController: UIGestureRecognizerDelegate {
     override open func viewDidLoad() {
         super.viewDidLoad()
         interactivePopGestureRecognizer?.delegate = self

--- a/Mogakco/Sources/Util/Extension/UINavigation+Swipe.swift
+++ b/Mogakco/Sources/Util/Extension/UINavigation+Swipe.swift
@@ -1,0 +1,20 @@
+//
+//  UINavigation+Swipe.swift
+//  Mogakco
+//
+//  Created by 김범수 on 2022/12/08.
+//  Copyright © 2022 Mogakco. All rights reserved.
+//
+
+import UIKit
+
+extension UINavigationController: ObservableObject, UIGestureRecognizerDelegate {
+    override open func viewDidLoad() {
+        super.viewDidLoad()
+        interactivePopGestureRecognizer?.delegate = self
+    }
+
+    public func gestureRecognizerShouldBegin(_: UIGestureRecognizer) -> Bool {
+        return viewControllers.count > 1
+    }
+}


### PR DESCRIPTION
### PR Type

- [x]  기능 추가 🔨
- [ ]  버그 수정 🐞
- [ ]  리팩토링 🚧
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [ ]  테스트 🔍
 

### Related Issue(작업 내용)

- resolve #251 
    - 채팅 Cell 내 프로필 선택 시 유저 상세 화면 이동 구현
-  ChatViewModel Rx Traits 적용 및 메소드 분리
- UINaigationViewController에 기본적으로 Pop Swipe가 적용되도록 Extension을 추가하였습니다

### 참고 사항

타 유저 상세 화면 이동 시 NavigationBar를 표시하고 TitleHeaderView를 표시하기 위한 [이슈](https://github.com/boostcampwm-2022/iOS04-Mogakco/issues/395)를 생성하였습니다.

### Screenshots(Optional)

https://user-images.githubusercontent.com/73675540/206372763-4a94ebd2-2ca1-4530-bed3-7c551ccbbd1d.MP4

