### PR TITLE
Controller tap, selected, refresh 이벤트 발생 시 .throttle 오퍼레이터로 중복 방지

### DIFF
--- a/Mogakco/Sources/Presentation/Chat/ViewController/ChatListViewController.swift
+++ b/Mogakco/Sources/Presentation/Chat/ViewController/ChatListViewController.swift
@@ -62,8 +62,10 @@ final class ChatListViewController: UIViewController {
     func bind() {
         let input = ChatListViewModel.Input(
             viewWillAppear: rx.viewWillAppear.map { _ in }.asObservable(),
-            selectedChatRoom: chatRoomTableView.rx.modelSelected(ChatRoom.self).asObservable(),
-            deletedChatRoom: chatRoomTableView.rx.modelDeleted(ChatRoom.self).asObservable()
+            selectedChatRoom: chatRoomTableView.rx.modelSelected(ChatRoom.self)
+                .throttle(.seconds(1), scheduler: MainScheduler.asyncInstance),
+            deletedChatRoom: chatRoomTableView.rx.modelDeleted(ChatRoom.self)
+                .throttle(.seconds(1), scheduler: MainScheduler.asyncInstance)
         )
         let output = viewModel.transform(input: input)
 

--- a/Mogakco/Sources/Presentation/Chat/ViewController/ChatViewController.swift
+++ b/Mogakco/Sources/Presentation/Chat/ViewController/ChatViewController.swift
@@ -99,13 +99,19 @@ final class ChatViewController: UIViewController {
                 .rx.notification(UIApplication.willEnterForegroundNotification).map { _ in () },
             didEnterBackground: NotificationCenter.default
                 .rx.notification(UIApplication.didEnterBackgroundNotification).map { _ in () },
-            backButtonDidTap: backButton.rx.tap.asObservable(),
-            studyInfoButtonDidTap: studyInfoButton.rx.tap.asObservable(),
-            selectedSidebar: sidebarView.tableView.rx.itemSelected.asObservable(),
-            sendButtonDidTap: messageInputView.sendButton.rx.tap.asObservable(),
+            backButtonDidTap: backButton.rx.tap
+                .throttle(.seconds(1), scheduler: MainScheduler.asyncInstance),
+            studyInfoButtonDidTap: studyInfoButton.rx.tap
+                .throttle(.seconds(1), scheduler: MainScheduler.asyncInstance),
+            selectedSidebar: sidebarView.tableView.rx.itemSelected
+                .throttle(.seconds(1), scheduler: MainScheduler.asyncInstance),
+            sendButtonDidTap: messageInputView.sendButton.rx.tap
+                .throttle(.seconds(1), scheduler: MainScheduler.asyncInstance),
             inputViewText: messageInputView.messageInputTextView.rx.text.orEmpty.asObservable(),
-            pagination: collectionView.refreshControl?.rx.controlEvent(.valueChanged).asObservable(),
-            selectedUser: selectedUser.asObservable()
+            pagination: collectionView.refreshControl?.rx.controlEvent(.valueChanged)
+                .throttle(.seconds(1), scheduler: MainScheduler.asyncInstance),
+            selectedUser: selectedUser
+                .throttle(.seconds(1), scheduler: MainScheduler.asyncInstance)
         )
         let output = viewModel.transform(input: input)
         

--- a/Mogakco/Sources/Presentation/Common/ViewController/AlertModalViewController.swift
+++ b/Mogakco/Sources/Presentation/Common/ViewController/AlertModalViewController.swift
@@ -60,6 +60,7 @@ final class AlertModalViewController: UIViewController {
             confirmButton.rx.tap.map { _ in true },
             cancelButton.rx.tap.map { _ in false }
         ])
+        .throttle(.seconds(1), scheduler: MainScheduler.asyncInstance)
         .subscribe(onNext: { [weak self] in
             observer?.onNext($0)
             self?.dismiss(animated: true)

--- a/Mogakco/Sources/Presentation/Hashtag/ViewController/HashtagSelectViewController.swift
+++ b/Mogakco/Sources/Presentation/Hashtag/ViewController/HashtagSelectViewController.swift
@@ -89,9 +89,12 @@ class HashtagSelectViewController: ViewController {
     override func bind() {
         let input = HashtagViewModel.Input(
             kindHashtag: Observable.just(kind),
-            cellSelected: cellSelect.asObservable(),
-            nextButtonTapped: nextButton.rx.tap.asObservable(),
-            backButtonTapped: backButton.rx.tap.asObservable()
+            cellSelected: cellSelect
+                .throttle(.seconds(1), scheduler: MainScheduler.asyncInstance),
+            nextButtonTapped: nextButton.rx.tap
+                .throttle(.seconds(1), scheduler: MainScheduler.asyncInstance),
+            backButtonTapped: backButton.rx.tap
+                .throttle(.seconds(1), scheduler: MainScheduler.asyncInstance)
         )
         
         let output = viewModel.transform(input: input)

--- a/Mogakco/Sources/Presentation/Login/ViewController/LoginViewController.swift
+++ b/Mogakco/Sources/Presentation/Login/ViewController/LoginViewController.swift
@@ -90,8 +90,10 @@ final class LoginViewController: ViewController {
             viewWillAppear: rx.viewWillAppear.map { _ in }.asObservable(),
             email: emailTextField.rx.text.orEmpty.asObservable(),
             password: secureTextField.rx.text.orEmpty.asObservable(),
-            signupButtonTap: signupButton.rx.tap.asObservable(),
-            loginButtonTap: loginButton.rx.tap.asObservable()
+            signupButtonTap: signupButton.rx.tap
+                .throttle(.seconds(1), scheduler: MainScheduler.asyncInstance),
+            loginButtonTap: loginButton.rx.tap
+                .throttle(.seconds(1), scheduler: MainScheduler.asyncInstance)
         )
 
         let output = viewModel.transform(input: input)

--- a/Mogakco/Sources/Presentation/Profile/ViewController/EditProfileViewController.swift
+++ b/Mogakco/Sources/Presentation/Profile/ViewController/EditProfileViewController.swift
@@ -87,8 +87,10 @@ final class EditProfileViewController: ViewController {
             name: nameCountTextField.rx.text.orEmpty.asObservable(),
             introduce: introuceCountTextView.rx.text.orEmpty.asObservable(),
             selectedProfileImage: selectedProfileImage.asObservable(),
-            completeButtonTapped: completeButton.rx.tap.asObservable(),
-            backButtonTapped: backButton.rx.tap.asObservable()
+            completeButtonTapped: completeButton.rx.tap
+                .throttle(.seconds(1), scheduler: MainScheduler.asyncInstance),
+            backButtonTapped: backButton.rx.tap
+                .throttle(.seconds(1), scheduler: MainScheduler.asyncInstance)
         )
         
         let output = viewModel.transform(input: input)

--- a/Mogakco/Sources/Presentation/Profile/ViewController/ProfileViewController.swift
+++ b/Mogakco/Sources/Presentation/Profile/ViewController/ProfileViewController.swift
@@ -128,15 +128,20 @@ final class ProfileViewController: UIViewController {
     func bind() {
         let input = ProfileViewModel.Input(
             viewWillAppear: rx.viewWillAppear.map { _ in }.asObservable(),
-            editProfileButtonTapped: profileView.editProfileButton.rx.tap.asObservable(),
-            chatButtonTapped: profileView.chatButton.rx.tap.asObservable(),
+            editProfileButtonTapped: profileView.editProfileButton.rx.tap
+                .throttle(.seconds(1), scheduler: MainScheduler.asyncInstance),
+            chatButtonTapped: profileView.chatButton.rx.tap
+                .throttle(.seconds(1), scheduler: MainScheduler.asyncInstance),
             hashtagEditButtonTapped: Observable.merge(
                 languageListView.editButton.rx.tap.map { _ in KindHashtag.language },
                 careerListView.editButton.rx.tap.map { _ in KindHashtag.career },
                 categoryListView.editButton.rx.tap.map { _ in KindHashtag.category }
-            ),
-            settingButtonTapped: settingButton.rx.tap.asObservable(),
-            reportButtonTapped: report.asObservable()
+            )
+            .throttle(.seconds(1), scheduler: MainScheduler.asyncInstance),
+            settingButtonTapped: settingButton.rx.tap
+                .throttle(.seconds(1), scheduler: MainScheduler.asyncInstance),
+            reportButtonTapped: report
+                .throttle(.seconds(1), scheduler: MainScheduler.asyncInstance)
         )
         let output = viewModel.transform(input: input)
         

--- a/Mogakco/Sources/Presentation/Setting/ViewController/SettingViewController.swift
+++ b/Mogakco/Sources/Presentation/Setting/ViewController/SettingViewController.swift
@@ -69,9 +69,12 @@ final class SettingViewController: ViewController {
     override func bind() {
         
         let input = SettingViewModel.Input(
-            logoutDidTap: logoutDidTap.asObservable(),
-            withdrawDidTap: withdrawDidTap.asObservable(),
-            backButtonDidTap: backButton.rx.tap.asObservable()
+            logoutDidTap: logoutDidTap
+                .throttle(.seconds(1), scheduler: MainScheduler.asyncInstance),
+            withdrawDidTap: withdrawDidTap
+                .throttle(.seconds(1), scheduler: MainScheduler.asyncInstance),
+            backButtonDidTap: backButton.rx.tap
+                .throttle(.seconds(1), scheduler: MainScheduler.asyncInstance)
         )
         
         _ = viewModel?.transform(input: input)
@@ -88,6 +91,7 @@ final class SettingViewController: ViewController {
             .disposed(by: disposeBag)
         
         tableView.rx.itemSelected
+            .throttle(.seconds(1), scheduler: MainScheduler.asyncInstance)
             .map { SettingMenu(row: $0.row) }
             .subscribe(onNext: { [weak self] row in
                 switch row {

--- a/Mogakco/Sources/Presentation/Setting/ViewController/WithdrawViewController.swift
+++ b/Mogakco/Sources/Presentation/Setting/ViewController/WithdrawViewController.swift
@@ -92,8 +92,10 @@ final class WithdrawViewController: ViewController {
     
     override func bind() {
         let input = WithdrawViewModel.Input(
-            backButtonDidTap: backButton.rx.tap.asObservable(),
-            withdrawButtonDidTap: withdrawButton.rx.tap.asObservable()
+            backButtonDidTap: backButton.rx.tap
+                .throttle(.seconds(1), scheduler: MainScheduler.asyncInstance),
+            withdrawButtonDidTap: withdrawButton.rx.tap
+                .throttle(.seconds(1), scheduler: MainScheduler.asyncInstance)
         )
         
         let output = viewModel?.transform(input: input)

--- a/Mogakco/Sources/Presentation/Signup/ViewController/PolicyViewController.swift
+++ b/Mogakco/Sources/Presentation/Signup/ViewController/PolicyViewController.swift
@@ -84,8 +84,10 @@ final class PolicyViewController: ViewController {
             totalPolicy: totalPolicy.checkButton.rx.isSelected.asObservable(),
             servicePolicy: servicePolicy.checkButton.rx.isSelected.asObservable(),
             contentPolicy: contentPolicy.checkButton.rx.isSelected.asObservable(),
-            nextButtonTapped: button.rx.tap.asObservable(),
-            backButtonTapped: backButton.rx.tap.asObservable()
+            nextButtonTapped: button.rx.tap
+                .throttle(.seconds(1), scheduler: MainScheduler.asyncInstance),
+            backButtonTapped: backButton.rx.tap
+                .throttle(.seconds(1), scheduler: MainScheduler.asyncInstance)
         )
         
         let output = viewModel.transform(input: input)

--- a/Mogakco/Sources/Presentation/Signup/ViewController/SetEmailViewController.swift
+++ b/Mogakco/Sources/Presentation/Signup/ViewController/SetEmailViewController.swift
@@ -86,8 +86,10 @@ final class SetEmailViewController: ViewController {
         
         let input = SetEmailViewModel.Input(
             email: textField.rx.text.orEmpty.asObservable(),
-            nextButtonTapped: button.rx.tap.asObservable(),
-            backButtonTapped: backButton.rx.tap.asObservable()
+            nextButtonTapped: button.rx.tap
+                .throttle(.seconds(1), scheduler: MainScheduler.asyncInstance),
+            backButtonTapped: backButton.rx.tap
+                .throttle(.seconds(1), scheduler: MainScheduler.asyncInstance)
         )
         
         let output = viewModel.transform(input: input)

--- a/Mogakco/Sources/Presentation/Signup/ViewController/SetPasswordViewController.swift
+++ b/Mogakco/Sources/Presentation/Signup/ViewController/SetPasswordViewController.swift
@@ -88,8 +88,10 @@ final class SetPasswordViewController: ViewController {
         let input = SetPasswordViewModel.Input(
             password: passwordTextField.rx.text.orEmpty.asObservable(),
             passwordCheck: passwordCheckTextField.rx.text.orEmpty.asObservable(),
-            nextButtonTapped: button.rx.tap.asObservable(),
-            backButtonTapped: backButton.rx.tap.asObservable()
+            nextButtonTapped: button.rx.tap
+                .throttle(.seconds(1), scheduler: MainScheduler.asyncInstance),
+            backButtonTapped: backButton.rx.tap
+                .throttle(.seconds(1), scheduler: MainScheduler.asyncInstance)
         )
         
         let output = viewModel.transform(input: input)

--- a/Mogakco/Sources/Presentation/Study/ViewController/CreateStudyViewController.swift
+++ b/Mogakco/Sources/Presentation/Study/ViewController/CreateStudyViewController.swift
@@ -146,10 +146,14 @@ final class CreateStudyViewController: ViewController {
             place: placeTextField.rx.text.orEmpty.asObservable(),
             maxUserCount: countStepper.stepper.rx.value.asObservable(),
             date: date.asObserver(),
-            categoryButtonTapped: categorySelect.button.rx.tap.asObservable(),
-            languageButtonTapped: languageSelect.button.rx.tap.asObservable(),
-            createButtonTapped: createButton.rx.tap.asObservable(),
-            backButtonTapped: backButton.rx.tap.asObservable()
+            categoryButtonTapped: categorySelect.button.rx.tap
+                .throttle(.seconds(1), scheduler: MainScheduler.asyncInstance),
+            languageButtonTapped: languageSelect.button.rx.tap
+                .throttle(.seconds(1), scheduler: MainScheduler.asyncInstance),
+            createButtonTapped: createButton.rx.tap
+                .throttle(.seconds(1), scheduler: MainScheduler.asyncInstance),
+            backButtonTapped: backButton.rx.tap
+                .throttle(.seconds(1), scheduler: MainScheduler.asyncInstance)
         )
         
         let output = viewModel.transform(input: input)

--- a/Mogakco/Sources/Presentation/Study/ViewController/SelectStudySortViewController.swift
+++ b/Mogakco/Sources/Presentation/Study/ViewController/SelectStudySortViewController.swift
@@ -54,7 +54,8 @@ final class SelectStudySortViewController: ViewController {
     
     override func bind() {
         let input = SelectStudySortViewModel.Input(
-            selectedStudySort: sortCollectionView.rx.modelSelected(StudySort.self).asObservable()
+            selectedStudySort: sortCollectionView.rx.modelSelected(StudySort.self)
+                .throttle(.seconds(1), scheduler: MainScheduler.asyncInstance)
         )
         
         let output = viewModel.transform(input: input)

--- a/Mogakco/Sources/Presentation/Study/ViewController/StudyDetailViewController.swift
+++ b/Mogakco/Sources/Presentation/Study/ViewController/StudyDetailViewController.swift
@@ -145,10 +145,13 @@ final class StudyDetailViewController: UIViewController {
     
     func bind() {
         let input = StudyDetailViewModel.Input(
-            studyJoinButtonTapped: studyJoinButton.rx.tap.asObservable(),
-            selectParticipantCell: participantsCollectionView.rx.modelSelected(User.self).asObservable(),
-            backButtonTapped: backButton.rx.tap.asObservable(),
-            reportButtonTapped: report.asObservable()
+            studyJoinButtonTapped: studyJoinButton.rx.tap
+                .throttle(.seconds(1), scheduler: MainScheduler.asyncInstance),
+            selectParticipantCell: participantsCollectionView.rx.modelSelected(User.self)
+                .throttle(.seconds(1), scheduler: MainScheduler.asyncInstance),
+            backButtonTapped: backButton.rx.tap
+                .throttle(.seconds(1), scheduler: MainScheduler.asyncInstance),
+            reportButtonTapped: report.throttle(.seconds(1), scheduler: MainScheduler.asyncInstance)
         )
         
         let output = viewModel.transform(input: input)

--- a/Mogakco/Sources/Presentation/Study/ViewController/StudyListViewController.swift
+++ b/Mogakco/Sources/Presentation/Study/ViewController/StudyListViewController.swift
@@ -63,13 +63,20 @@ final class StudyListViewController: ViewController {
         
         let input = StudyListViewModel.Input(
             viewWillAppear: self.rx.viewWillAppear.map { _ in () }.asObservable(),
-            plusButtonTapped: header.plusButton.rx.tap.asObservable(),
-            cellSelected: collectionView.rx.itemSelected.asObservable(),
-            refresh: refreshControl.rx.controlEvent(.valueChanged).asObservable(),
-            sortButtonTapped: header.sortButton.rx.tap.asObservable(),
-            languageButtonTapped: header.languageButton.rx.tap.asObservable(),
-            categoryButtonTapped: header.categoryButton.rx.tap.asObservable(),
-            resetButtonTapped: header.resetButton.rx.tap.asObservable()
+            plusButtonTapped: header.plusButton.rx.tap
+                .throttle(.seconds(1), scheduler: MainScheduler.asyncInstance),
+            cellSelected: collectionView.rx.itemSelected
+                .throttle(.seconds(1), scheduler: MainScheduler.asyncInstance),
+            refresh: refreshControl.rx.controlEvent(.valueChanged)
+                .throttle(.seconds(1), scheduler: MainScheduler.asyncInstance),
+            sortButtonTapped: header.sortButton.rx.tap
+                .throttle(.seconds(1), scheduler: MainScheduler.asyncInstance),
+            languageButtonTapped: header.languageButton.rx.tap
+                .throttle(.seconds(1), scheduler: MainScheduler.asyncInstance),
+            categoryButtonTapped: header.categoryButton.rx.tap
+                .throttle(.seconds(1), scheduler: MainScheduler.asyncInstance),
+            resetButtonTapped: header.resetButton.rx.tap
+                .throttle(.seconds(1), scheduler: MainScheduler.asyncInstance)
         )
         
         let output = viewModel.transform(input: input)


### PR DESCRIPTION
### PR Type

- [x]  기능 추가 🔨
- [ ]  버그 수정 🐞
- [ ]  리팩토링 🚧
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [ ]  테스트 🔍
 

### Related Issue(작업 내용)

Controller에서 Button Tap, Item Selected, Refresh 이벤트 등에 throttle 오퍼레이터를 추가해 1초간 중복 이벤트를 방지하도록 하였습니다.
