### PR TITLE
채팅 유저 이름 및 시간 표시

### DIFF
--- a/Mogakco/Sources/Presentation/Chat/View/ChatCell.swift
+++ b/Mogakco/Sources/Presentation/Chat/View/ChatCell.swift
@@ -64,6 +64,7 @@ final class ChatCell: UICollectionViewCell, Identifiable {
         layoutProfileImageButton()
         layoutBubbleContainerView()
         layoutTextView()
+        layoutTimeLabel()
     }
     
     private func layoutCell() {
@@ -114,6 +115,10 @@ final class ChatCell: UICollectionViewCell, Identifiable {
         }
     }
     
+    private func layoutTimeLabel() {
+        addSubview(timeLabel)
+    }
+    
     func layoutChat(chat: Chat) {
         guard
             let isFromCurrentUser = chat.isFromCurrentUser,
@@ -137,6 +142,11 @@ final class ChatCell: UICollectionViewCell, Identifiable {
         }
         bubbleContainer.backgroundColor = .mogakcoColor.primarySecondary
         
+        timeLabel.snp.remakeConstraints {
+            $0.left.equalTo(bubbleContainer.snp.right).offset(4)
+            $0.bottom.equalTo(bubbleContainer)
+        }
+        
         if let image = image {
             profileImageView.image = image
             nameLabel.text = "탈퇴한 유저"
@@ -155,6 +165,13 @@ final class ChatCell: UICollectionViewCell, Identifiable {
             $0.right.equalToSuperview().inset(12)
             $0.width.lessThanOrEqualTo(200)
         }
+        
+        timeLabel.snp.remakeConstraints {
+            $0.right.equalTo(bubbleContainer.snp.left) // TODO: inset, offset 둘다 이상하게 먹음
+            $0.bottom.equalTo(bubbleContainer)
+        }
+
+        nameLabel.isHidden = true
         bubbleContainer.backgroundColor = .mogakcoColor.primaryDefault
         profileImageView.isHidden = true
     }

--- a/Mogakco/Sources/Presentation/Chat/View/ChatCell.swift
+++ b/Mogakco/Sources/Presentation/Chat/View/ChatCell.swift
@@ -54,6 +54,7 @@ final class ChatCell: UICollectionViewCell, Identifiable {
     
     private func layout() {
         layoutCell()
+        layoutNameLabel()
         layoutProfileImageView()
         layoutProfileImageButton()
         layoutBubbleContainerView()
@@ -62,6 +63,15 @@ final class ChatCell: UICollectionViewCell, Identifiable {
     
     private func layoutCell() {
         backgroundColor = .mogakcoColor.backgroundDefault
+    }
+    
+    private func layoutNameLabel() {
+        addSubview(nameLabel)
+        
+        nameLabel.snp.makeConstraints {
+            $0.top.equalToSuperview().offset(4)
+            $0.left.equalToSuperview().inset(12)
+        }
     }
     
     private func layoutProfileImageView() {
@@ -129,6 +139,7 @@ final class ChatCell: UICollectionViewCell, Identifiable {
         if let user = user,
            let urlStr = user.profileImageURLString,
            let url = URL(string: urlStr) {
+            nameLabel.text = user.name
             profileImageView.load(url: url)
         }
     }

--- a/Mogakco/Sources/Presentation/Chat/View/ChatCell.swift
+++ b/Mogakco/Sources/Presentation/Chat/View/ChatCell.swift
@@ -134,6 +134,7 @@ final class ChatCell: UICollectionViewCell, Identifiable {
         
         if let image = image {
             profileImageView.image = image
+            nameLabel.text = "탈퇴한 유저"
         }
         
         if let user = user,

--- a/Mogakco/Sources/Presentation/Chat/View/ChatCell.swift
+++ b/Mogakco/Sources/Presentation/Chat/View/ChatCell.swift
@@ -29,6 +29,11 @@ final class ChatCell: UICollectionViewCell, Identifiable {
         $0.layer.cornerRadius = 8
     }
     
+    let nameLabel = UILabel().then {
+        $0.textColor = .mogakcoColor.typographySecondary
+        $0.font = UIFont.mogakcoFont.smallBold
+    }
+    
     override init(frame: CGRect) {
         super.init(frame: frame)
         layout()

--- a/Mogakco/Sources/Presentation/Chat/View/ChatCell.swift
+++ b/Mogakco/Sources/Presentation/Chat/View/ChatCell.swift
@@ -34,6 +34,11 @@ final class ChatCell: UICollectionViewCell, Identifiable {
         $0.font = UIFont.mogakcoFont.smallBold
     }
     
+    private let timeLabel = UILabel().then {
+        $0.textColor = .mogakcoColor.typographySecondary
+        $0.font = UIFont.mogakcoFont.smallRegular
+    }
+    
     override init(frame: CGRect) {
         super.init(frame: frame)
         layout()

--- a/Mogakco/Sources/Presentation/Chat/View/ChatCell.swift
+++ b/Mogakco/Sources/Presentation/Chat/View/ChatCell.swift
@@ -131,6 +131,7 @@ final class ChatCell: UICollectionViewCell, Identifiable {
         }
         
         textView.text = chat.message
+        timeLabel.text = chat.date.toChatCompactDateString()
     }
     
     private func layoutOthersBubble(user: User? = nil, image: UIImage? = nil) {

--- a/Mogakco/Sources/Presentation/Chat/View/ChatCell.swift
+++ b/Mogakco/Sources/Presentation/Chat/View/ChatCell.swift
@@ -84,8 +84,8 @@ final class ChatCell: UICollectionViewCell, Identifiable {
         addSubview(profileImageView)
         
         profileImageView.snp.makeConstraints {
+            $0.top.equalTo(nameLabel.snp.bottom).offset(4)
             $0.left.equalToSuperview().offset(12)
-            $0.top.equalToSuperview().offset(4)
         }
     }
     
@@ -99,11 +99,6 @@ final class ChatCell: UICollectionViewCell, Identifiable {
     
     private func layoutBubbleContainerView() {
         addSubview(bubbleContainer)
-        
-        bubbleContainer.snp.makeConstraints {
-            $0.top.bottom.equalToSuperview()
-            $0.width.lessThanOrEqualTo(200)
-        }
     }
     
     private func layoutTextView() {
@@ -137,7 +132,8 @@ final class ChatCell: UICollectionViewCell, Identifiable {
     
     private func layoutOthersBubble(user: User? = nil, image: UIImage? = nil) {
         bubbleContainer.snp.remakeConstraints {
-            $0.left.equalTo(profileImageView.snp.right).offset(12)
+            $0.bottom.equalToSuperview()
+            $0.left.equalTo(profileImageView.snp.right).offset(8)
             $0.width.lessThanOrEqualTo(200)
         }
         bubbleContainer.backgroundColor = .mogakcoColor.primarySecondary
@@ -162,7 +158,8 @@ final class ChatCell: UICollectionViewCell, Identifiable {
     
     private func layoutMyBubble() {
         bubbleContainer.snp.remakeConstraints {
-            $0.right.equalToSuperview().inset(12)
+            $0.bottom.equalToSuperview()
+            $0.right.equalToSuperview().inset(8)
             $0.width.lessThanOrEqualTo(200)
         }
         

--- a/Mogakco/Sources/Presentation/Chat/View/ChatCell.swift
+++ b/Mogakco/Sources/Presentation/Chat/View/ChatCell.swift
@@ -54,6 +54,9 @@ final class ChatCell: UICollectionViewCell, Identifiable {
         profileImageView.isHidden = false
         profileImageView.image = UIImage(systemName: "person")
         textView.text = nil
+        nameLabel.isHidden = false
+        nameLabel.text = nil
+        timeLabel.snp.removeConstraints()
         bubbleContainer.snp.removeConstraints()
     }
     

--- a/Mogakco/Sources/Presentation/Chat/ViewController/ChatViewController.swift
+++ b/Mogakco/Sources/Presentation/Chat/ViewController/ChatViewController.swift
@@ -188,6 +188,7 @@ final class ChatViewController: UIViewController {
         layoutSideBar()
         layoutBlackScreen()
         layoutMessageInputView()
+        layoutNavigationBar()
     }
     
     private func configure() {

--- a/Mogakco/Sources/Presentation/Chat/ViewController/ChatViewController.swift
+++ b/Mogakco/Sources/Presentation/Chat/ViewController/ChatViewController.swift
@@ -20,6 +20,7 @@ final class ChatViewController: UIViewController {
     
     enum Constant {
         static let messageInputViewHeight = 100.0
+        static let collectionViewSpacing = 12.0
         static let sidebarZPosition = 100.0
         static let collectionViewHeight = 60
     }
@@ -39,7 +40,7 @@ final class ChatViewController: UIViewController {
         layout.scrollDirection = .vertical
         layout.sectionInset = UIEdgeInsets(top: 16, left: 0, bottom: 0, right: 0)
         layout.itemSize = CGSize(width: view.frame.width, height: 60)
-        layout.minimumLineSpacing = 12.0
+        layout.minimumLineSpacing = Constant.collectionViewSpacing
         $0.refreshControl = UIRefreshControl()
         $0.collectionViewLayout = layout
         $0.register(ChatCell.self, forCellWithReuseIdentifier: ChatCell.identifier)
@@ -366,7 +367,7 @@ extension ChatViewController: UICollectionViewDelegateFlowLayout {
         estimatedCell.layoutChat(chat: viewModel.messages.value[indexPath.item])
         estimatedCell.layoutIfNeeded()
         
-        let height = estimatedCell.bubbleContainer.frame.height
+        let height = estimatedCell.bubbleContainer.frame.height + estimatedCell.nameLabel.frame.height + 4.0
         
         return .init(width: view.frame.width, height: height)
     }

--- a/Mogakco/Sources/Util/Extension/Int+Formatter.swift
+++ b/Mogakco/Sources/Util/Extension/Int+Formatter.swift
@@ -55,4 +55,30 @@ extension Int {
         
         return dateString.trimmingCharacters(in: [" "])
     }
+    
+    /// ex) 202212011700 ==> 오후 5시
+    func toChatCompactDateString() -> String {
+        var number = self / 100
+        let date: [Int] = [100, 100].map {
+            let remain = number % $0
+            number /= $0
+            return remain
+        }
+        
+        let all = zip(date.reversed(), ["시", "분"])
+        
+        let dateString = all.reduce("") { result, info in
+            let (num, unit) = info
+            if unit == "분" && num == 0 { return result }
+            if unit == "시" {
+                let hour = num <= 12 ? num : num - 12
+                let ampm = num < 12 ? "오전" : "오후"
+                return "\(result) \(ampm) \(hour)\(unit)"
+            } else {
+                return "\(result) \(num)\(unit)"
+            }
+        }
+        
+        return dateString.trimmingCharacters(in: [" "])
+    }
 }

--- a/Mogakco/Sources/Util/Extension/Int+Formatter.swift
+++ b/Mogakco/Sources/Util/Extension/Int+Formatter.swift
@@ -73,9 +73,9 @@ extension Int {
             if unit == "시" {
                 let hour = num <= 12 ? num : num - 12
                 let ampm = num < 12 ? "오전" : "오후"
-                return "\(result) \(ampm) \(hour)\(unit)"
+                return "\(result) \(ampm) \(hour):"
             } else {
-                return "\(result) \(num)\(unit)"
+                return "\(result)\(num)"
             }
         }
         


### PR DESCRIPTION
### PR Type

- [x]  기능 추가 🔨
- [ ]  버그 수정 🐞
- [ ]  리팩토링 🚧
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [ ]  테스트 🔍
 

### Related Issue(작업 내용)

> 이슈 번호와 구현 내용 및 작업 했던 내역을 입력해주세요!
- close #409 
  - 탈퇴한 회원 채팅 처리
- close #408 
  - 채팅 이름 표시 
- close #307
  - 메세지 시간 표시 

### 참고 사항
- 날짜까지 같이 표시하면 글이 길어져서 시간만 표시 했는데 날짜 처리가 애매합니다. 폰트 줄여서 날짜까지 같이 표시하려구요..
- 시간 라벨의 컨스트레인트는  equalTo(상대방bubble.snp.right).offset(8) 하면 적용이 되는데 본인 시간 라벨은 bubble.snp.right에 offset은 먹히는데 inset은 적용이 안되네요.. 그래서 일단 딱 붙여놨는데 왜 그럴까요 ㅠㅠ
- 머지하면서 코드가 좀 빠지거나 변경된게 있는거 같아 그 부분들 찾아서 수정하겠습니다!

### Screenshots(Optional)
<img src="https://user-images.githubusercontent.com/75964073/206620224-be29667d-f9f1-49cc-8297-df0eb647cb5e.png" width="50%">