### PR TITLE
채팅방 목록 유저, 채팅방 정렬 오류 수정

### DIFF
--- a/Mogakco/Sources/Presentation/Chat/View/ChatRoomUsersImageView.swift
+++ b/Mogakco/Sources/Presentation/Chat/View/ChatRoomUsersImageView.swift
@@ -58,7 +58,7 @@ final class ChatRoomUsersImageView: UIView {
     func configure(imageURLs: [URL]) -> Observable<Bool> {
         var observables: [Observable<Bool>] = []
         
-        zip(imageURLs.shuffled(), roundImageViews).forEach { imageURL, roundImageView in
+        zip(imageURLs, roundImageViews).forEach { imageURL, roundImageView in
             observables.append(roundImageView.loadAndEvent(url: imageURL))
 //            roundImageView.load(url: imageURL)
         }


### PR DESCRIPTION
### PR Type

- [ ]  기능 추가 🔨
- [x]  버그 수정 🐞
- [x]  리팩토링 🚧
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [ ]  테스트 🔍
 

### Related Issue(작업 내용)

- resolvs #401 
    - 채팅방 유저 이미지 순서를 shuffle하고 있는 로직이 있어 제거하여 리로드해도 변동이 없도록 개선하였습니다.
- 채팅방 목록을 최근 문자 날짜 순서로 정렬합니다. 
-  resolves #391 
  - ChatRepository 내 메소드들의 비동기 코드를 리팩토링 하였습니다

### 참고 사항
채팅방 목록에서 최근 메세지가 없는 경우 밑으로 내려가게 되는 문제가 있네요..
최근에 생성한 채팅방이더라도 문자를 안보내면 밑에 존재하게되는.. 좋은 해결 방법이 있을까요?