### PR TITLE
채팅 읽었을 때 readUserIDs에 추가

### DIFF
--- a/Mogakco/Sources/Data/DataSources/Protocol/ChatDataSourceProtocol.swift
+++ b/Mogakco/Sources/Data/DataSources/Protocol/ChatDataSourceProtocol.swift
@@ -12,4 +12,5 @@ protocol ChatDataSourceProtocol {
     func fetch(chatRoomID: String) -> Observable<[ChatResponseDTO]>
     func observe(chatRoomID: String) -> Observable<ChatResponseDTO>
     func send(chat: Chat, to chatRoomID: String) -> Observable<Void>
+    func read(chat: Chat, userID: String) -> Observable<Void>
 }

--- a/Mogakco/Sources/Data/DataSources/Protocol/ChatDataSourceProtocol.swift
+++ b/Mogakco/Sources/Data/DataSources/Protocol/ChatDataSourceProtocol.swift
@@ -12,6 +12,6 @@ protocol ChatDataSourceProtocol {
     func fetch(chatRoomID: String) -> Observable<[ChatResponseDTO]>
     func observe(chatRoomID: String) -> Observable<ChatResponseDTO>
     func send(chat: Chat, to chatRoomID: String) -> Observable<Void>
-    func read(chat: Chat, userID: String) -> Observable<Void>
+    func read(chat: Chat) -> Observable<Void>
     func stopObserving()
 }

--- a/Mogakco/Sources/Data/DataSources/Protocol/ChatDataSourceProtocol.swift
+++ b/Mogakco/Sources/Data/DataSources/Protocol/ChatDataSourceProtocol.swift
@@ -13,4 +13,5 @@ protocol ChatDataSourceProtocol {
     func observe(chatRoomID: String) -> Observable<ChatResponseDTO>
     func send(chat: Chat, to chatRoomID: String) -> Observable<Void>
     func read(chat: Chat, userID: String) -> Observable<Void>
+    func stopObserving()
 }

--- a/Mogakco/Sources/Data/DataSources/Remote/ChatDataSource.swift
+++ b/Mogakco/Sources/Data/DataSources/Remote/ChatDataSource.swift
@@ -94,20 +94,15 @@ final class ChatDataSource: ChatDataSourceProtocol {
         }
     }
     
-    func read(chat: Chat, userID: String) -> Observable<Void> {
+    func read(chat: Chat) -> Observable<Void> {
         return Observable.create { emitter in
-            if !chat.readUserIDs.contains(userID) {
-                var chat2 = chat
-                
-                chat2.readUserIDs += [userID]
-                Constant.chatRoom
-                    .document(chat.chatRoomID)
-                    .collection("chat")
-                    .document(chat.id)
-                    .updateData(["readUserIDs": chat2.readUserIDs]) { _ in
-                        emitter.onNext(())
-                    }
-            }
+            Constant.chatRoom
+                .document(chat.chatRoomID)
+                .collection("chat")
+                .document(chat.id)
+                .updateData(["readUserIDs": chat.readUserIDs]) { _ in
+                    emitter.onNext(())
+                }
             return Disposables.create()
         }
     }

--- a/Mogakco/Sources/Data/DataSources/Remote/ChatDataSource.swift
+++ b/Mogakco/Sources/Data/DataSources/Remote/ChatDataSource.swift
@@ -66,6 +66,7 @@ final class ChatDataSource: ChatDataSourceProtocol {
                 if let snapshot = snapshot,
                    let change = snapshot.documentChanges.last,
                    change.type == .added {
+                    // type 지정 안하면 1. 채팅 등록 2.상대가 읽은거 인해서 총 2번 오니까 add 항목만 오게 확인 해야함
                     let dictionary = change.document.data()
                     guard let data = try? JSONSerialization.data(withJSONObject: dictionary),
                           let chat = try? JSONDecoder().decode(Chat.self, from: data)
@@ -92,9 +93,6 @@ final class ChatDataSource: ChatDataSourceProtocol {
     
     func read(chat: Chat, userID: String) -> Observable<Void> {
         return Observable.create { emitter in
-            print("DEBUG : READ userID \(userID)")
-            print("DEBUG : READ userID \(chat.readUserIDs)")
-            print("DEBUG : READ readUserIDs.contains \(!chat.readUserIDs.contains(userID))")
             if !chat.readUserIDs.contains(userID) {
                 var chat2 = chat
                 
@@ -109,5 +107,11 @@ final class ChatDataSource: ChatDataSourceProtocol {
             }
             return Disposables.create()
         }
+    }
+    
+    func stopObserving() {
+        listener?.remove()
+        listener = nil
+        page = nil
     }
 }

--- a/Mogakco/Sources/Data/Repositories/ChatRepository.swift
+++ b/Mogakco/Sources/Data/Repositories/ChatRepository.swift
@@ -45,4 +45,8 @@ struct ChatRepository: ChatRepositoryProtocol {
     func read(chat: Chat, userID: String) -> Observable<Void> {
         return chatDataSource?.read(chat: chat, userID: userID) ?? .empty()
     }
+    
+    func stopObserving() {
+        chatDataSource?.stopObserving()
+    }
 }

--- a/Mogakco/Sources/Data/Repositories/ChatRepository.swift
+++ b/Mogakco/Sources/Data/Repositories/ChatRepository.swift
@@ -42,8 +42,8 @@ struct ChatRepository: ChatRepositoryProtocol {
             .map { _ in () } ?? .empty()
     }
     
-    func read(chat: Chat, userID: String) -> Observable<Void> {
-        return chatDataSource?.read(chat: chat, userID: userID) ?? .empty()
+    func read(chat: Chat) -> Observable<Void> {
+        return chatDataSource?.read(chat: chat) ?? .empty()
     }
     
     func stopObserving() {

--- a/Mogakco/Sources/Data/Repositories/ChatRepository.swift
+++ b/Mogakco/Sources/Data/Repositories/ChatRepository.swift
@@ -41,4 +41,8 @@ struct ChatRepository: ChatRepositoryProtocol {
             .flatMap { pushNotificationService?.sendTopic(request: request) ?? .empty() }
             .map { _ in () } ?? .empty()
     }
+    
+    func read(chat: Chat, userID: String) -> Observable<Void> {
+        return chatDataSource?.read(chat: chat, userID: userID) ?? .empty()
+    }
 }

--- a/Mogakco/Sources/Domain/Entities/Chat.swift
+++ b/Mogakco/Sources/Domain/Entities/Chat.swift
@@ -14,7 +14,7 @@ struct Chat: Codable {
     let message: String
     let chatRoomID: String
     let date: Int
-    var readUserIDs: [String]
+    let readUserIDs: [String]
     var user: User?
     var isFromCurrentUser: Bool?
 }

--- a/Mogakco/Sources/Domain/Entities/Chat.swift
+++ b/Mogakco/Sources/Domain/Entities/Chat.swift
@@ -14,7 +14,7 @@ struct Chat: Codable {
     let message: String
     let chatRoomID: String
     let date: Int
-    let readUserIDs: [String]
+    var readUserIDs: [String]
     var user: User?
     var isFromCurrentUser: Bool?
 }

--- a/Mogakco/Sources/Domain/Repositories/ChatRepositoryProtocol.swift
+++ b/Mogakco/Sources/Domain/Repositories/ChatRepositoryProtocol.swift
@@ -12,6 +12,6 @@ protocol ChatRepositoryProtocol {
     func fetch(chatRoomID: String) -> Observable<[Chat]>
     func observe(chatRoomID: String) -> Observable<Chat>
     func send(chat: Chat, to chatRoomID: String) -> Observable<Void>
-    func read(chat: Chat, userID: String) -> Observable<Void>
+    func read(chat: Chat) -> Observable<Void>
     func stopObserving()
 }

--- a/Mogakco/Sources/Domain/Repositories/ChatRepositoryProtocol.swift
+++ b/Mogakco/Sources/Domain/Repositories/ChatRepositoryProtocol.swift
@@ -12,4 +12,5 @@ protocol ChatRepositoryProtocol {
     func fetch(chatRoomID: String) -> Observable<[Chat]>
     func observe(chatRoomID: String) -> Observable<Chat>
     func send(chat: Chat, to chatRoomID: String) -> Observable<Void>
+    func read(chat: Chat, userID: String) -> Observable<Void>
 }

--- a/Mogakco/Sources/Domain/Repositories/ChatRepositoryProtocol.swift
+++ b/Mogakco/Sources/Domain/Repositories/ChatRepositoryProtocol.swift
@@ -13,4 +13,5 @@ protocol ChatRepositoryProtocol {
     func observe(chatRoomID: String) -> Observable<Chat>
     func send(chat: Chat, to chatRoomID: String) -> Observable<Void>
     func read(chat: Chat, userID: String) -> Observable<Void>
+    func stopObserving()
 }

--- a/Mogakco/Sources/Domain/UseCases/ChatUseCase.swift
+++ b/Mogakco/Sources/Domain/UseCases/ChatUseCase.swift
@@ -52,6 +52,10 @@ struct ChatUseCase: ChatUseCaseProtocol {
         return chatRepository?.send(chat: chat, to: chatRoomID) ?? .empty()
     }
     
+    func read(chat: Chat, userID: String) -> Observable<Void> {
+        return chatRepository?.read(chat: chat, userID: userID) ?? .empty()
+    }
+    
     func myProfile() -> Observable<User> {
         return userRepository?.load() ?? .empty()
     }

--- a/Mogakco/Sources/Domain/UseCases/ChatUseCase.swift
+++ b/Mogakco/Sources/Domain/UseCases/ChatUseCase.swift
@@ -53,7 +53,16 @@ struct ChatUseCase: ChatUseCaseProtocol {
     }
     
     func read(chat: Chat, userID: String) -> Observable<Void> {
-        return chatRepository?.read(chat: chat, userID: userID) ?? .empty()
+        if chat.readUserIDs.contains(userID) { return Observable.just(()) }
+        let newChat = Chat(
+            id: chat.id,
+            userID: chat.userID,
+            message: chat.message,
+            chatRoomID: chat.chatRoomID,
+            date: chat.date,
+            readUserIDs: chat.readUserIDs + [userID]
+        )
+        return chatRepository?.read(chat: newChat) ?? .empty()
     }
     
     func stopObserving() {

--- a/Mogakco/Sources/Domain/UseCases/ChatUseCase.swift
+++ b/Mogakco/Sources/Domain/UseCases/ChatUseCase.swift
@@ -56,6 +56,10 @@ struct ChatUseCase: ChatUseCaseProtocol {
         return chatRepository?.read(chat: chat, userID: userID) ?? .empty()
     }
     
+    func stopObserving() {
+        chatRepository?.stopObserving()
+    }
+    
     func myProfile() -> Observable<User> {
         return userRepository?.load() ?? .empty()
     }

--- a/Mogakco/Sources/Domain/UseCases/Protocol/ChatUseCaseProtocol.swift
+++ b/Mogakco/Sources/Domain/UseCases/Protocol/ChatUseCaseProtocol.swift
@@ -13,5 +13,6 @@ protocol ChatUseCaseProtocol {
     func observe(chatRoomID: String) -> Observable<Chat>
     func send(chat: Chat, to chatRoomID: String) -> Observable<Void>
     func read(chat: Chat, userID: String) -> Observable<Void>
+    func stopObserving()
     func myProfile() -> Observable<User> 
 }

--- a/Mogakco/Sources/Domain/UseCases/Protocol/ChatUseCaseProtocol.swift
+++ b/Mogakco/Sources/Domain/UseCases/Protocol/ChatUseCaseProtocol.swift
@@ -12,5 +12,6 @@ protocol ChatUseCaseProtocol {
     func fetch(chatRoomID: String) -> Observable<[Chat]>
     func observe(chatRoomID: String) -> Observable<Chat>
     func send(chat: Chat, to chatRoomID: String) -> Observable<Void>
+    func read(chat: Chat, userID: String) -> Observable<Void>
     func myProfile() -> Observable<User> 
 }

--- a/Mogakco/Sources/Presentation/Chat/View/ChatCell.swift
+++ b/Mogakco/Sources/Presentation/Chat/View/ChatCell.swift
@@ -42,7 +42,6 @@ final class ChatCell: UICollectionViewCell, Identifiable {
     override init(frame: CGRect) {
         super.init(frame: frame)
         layout()
-        prepareForReuse()
     }
     
     required init?(coder: NSCoder) {
@@ -51,11 +50,12 @@ final class ChatCell: UICollectionViewCell, Identifiable {
     
     override func prepareForReuse() {
         super.prepareForReuse()
-        profileImageView.isHidden = false
         profileImageView.image = UIImage(systemName: "person")
         textView.text = nil
-        nameLabel.isHidden = false
         nameLabel.text = nil
+        timeLabel.text = nil
+        nameLabel.isHidden = false
+        profileImageView.isHidden = false
         timeLabel.snp.removeConstraints()
         bubbleContainer.snp.removeConstraints()
     }
@@ -122,7 +122,8 @@ final class ChatCell: UICollectionViewCell, Identifiable {
             let isFromCurrentUser = chat.isFromCurrentUser,
             let user = chat.user else {
             textView.text = chat.message
-            return layoutOthersBubble(image: UIImage(systemName: "person.fill")) }
+            timeLabel.text = chat.date.toChatCompactDateString()
+            return layoutOthersBubble() }
 
         if isFromCurrentUser {
             layoutMyBubble()
@@ -134,7 +135,7 @@ final class ChatCell: UICollectionViewCell, Identifiable {
         timeLabel.text = chat.date.toChatCompactDateString()
     }
     
-    private func layoutOthersBubble(user: User? = nil, image: UIImage? = nil) {
+    private func layoutOthersBubble(user: User? = nil) {
         bubbleContainer.snp.remakeConstraints {
             $0.bottom.equalToSuperview()
             $0.left.equalTo(profileImageView.snp.right).offset(8)
@@ -147,16 +148,16 @@ final class ChatCell: UICollectionViewCell, Identifiable {
             $0.bottom.equalTo(bubbleContainer)
         }
         
-        if let image = image {
-            profileImageView.image = image
+        if let user = user {
+            nameLabel.text = user.name
+        } else {
             nameLabel.text = "탈퇴한 유저"
         }
         
-        if let user = user,
-           let urlStr = user.profileImageURLString,
-           let url = URL(string: urlStr) {
-            nameLabel.text = user.name
+        if let url = URL(string: user?.profileImageURLString ?? "") {
             profileImageView.load(url: url)
+        } else {
+            profileImageView.image = UIImage(systemName: "person.fill")
         }
     }
     

--- a/Mogakco/Sources/Presentation/Chat/ViewModel/ChatViewModel.swift
+++ b/Mogakco/Sources/Presentation/Chat/ViewModel/ChatViewModel.swift
@@ -103,6 +103,21 @@ final class ChatViewModel: ViewModel {
             })
             .disposed(by: disposeBag)
         
+        Observable.combineLatest(
+            newChats,
+            chatUseCase?.myProfile() ?? .empty()
+        )
+        .flatMap { [weak self] chats, user in
+            let observe: [Observable<Void>] = chats.map {
+                self?.chatUseCase?.read(chat: $0, userID: user.id) ?? .empty()
+            }
+            return Observable
+                .combineLatest(observe)
+                .map { _ in }
+        }
+        .subscribe(onNext: { _ in })
+        .disposed(by: disposeBag)
+        
         input.pagination?
             .subscribe(refreshFinished)
             .disposed(by: disposeBag)

--- a/Mogakco/Sources/Presentation/Chat/ViewModel/ChatViewModel.swift
+++ b/Mogakco/Sources/Presentation/Chat/ViewModel/ChatViewModel.swift
@@ -93,7 +93,7 @@ final class ChatViewModel: ViewModel {
             .withUnretained(self)
             .flatMap { $0.0.chatUseCase?.fetch(chatRoomID: $0.0.chatRoomID).asResult() ?? .empty() }
             .withUnretained(self)
-            .subscribe(onNext: { viewModel, result in
+            .subscribe(onNext: { _, result in
                 switch result {
                 case .success(let chats):
                     newChats.onNext(chats)
@@ -101,6 +101,10 @@ final class ChatViewModel: ViewModel {
                     newChats.onNext([])
                 }
             })
+            .disposed(by: disposeBag)
+        
+        input.pagination?
+            .subscribe(refreshFinished)
             .disposed(by: disposeBag)
         
         newChats

--- a/Mogakco/Sources/Presentation/Chat/ViewModel/ChatViewModel.swift
+++ b/Mogakco/Sources/Presentation/Chat/ViewModel/ChatViewModel.swift
@@ -159,6 +159,14 @@ final class ChatViewModel: ViewModel {
             })
             .disposed(by: disposeBag)
         
+        newChat
+            .withLatestFrom(chatUseCase?.myProfile() ?? .empty()) { ($0, $1) }
+            .flatMap { [weak self] chat, user in
+                self?.chatUseCase?.read(chat: chat, userID: user.id) ?? .empty()
+            }
+            .subscribe(onNext: { _ in })
+            .disposed(by: disposeBag)
+        
         // 채팅 전송
         let profile = BehaviorSubject<User?>(value: nil)
         

--- a/Mogakco/Sources/Util/Extension/Int+Formatter.swift
+++ b/Mogakco/Sources/Util/Extension/Int+Formatter.swift
@@ -58,27 +58,19 @@ extension Int {
     
     /// ex) 202212011700 ==> 오후 5시
     func toChatCompactDateString() -> String {
-        var number = self / 100
-        let date: [Int] = [100, 100].map {
-            let remain = number % $0
-            number /= $0
-            return remain
+        let number = self / 100
+        let time = number % 10000
+        let hour = Int(Double(time) / 100.0)
+        let minutes = time % 100
+        var dateString = ""
+        
+        if hour - 12 > 1 {
+            dateString = "오후 \(String(format: "%02d", hour - 12)):\(String(format: "%02d", minutes))"
+        } else if hour - 12 == 0 {
+            dateString = "정오 12:\(String(format: "%02d", minutes))"
+        } else {
+            dateString = "오전 \(String(format: "%02d", hour)):\(String(format: "%02d", minutes))"
         }
-        
-        let all = zip(date.reversed(), ["시", "분"])
-        
-        let dateString = all.reduce("") { result, info in
-            let (num, unit) = info
-            if unit == "분" && num == 0 { return result }
-            if unit == "시" {
-                let hour = num <= 12 ? num : num - 12
-                let ampm = num < 12 ? "오전" : "오후"
-                return "\(result) \(ampm) \(hour):"
-            } else {
-                return "\(result)\(num)"
-            }
-        }
-        
-        return dateString.trimmingCharacters(in: [" "])
+        return dateString
     }
 }

--- a/Mogakco/Sources/Util/Extension/Int+Formatter.swift
+++ b/Mogakco/Sources/Util/Extension/Int+Formatter.swift
@@ -67,7 +67,7 @@ extension Int {
         if hour - 12 > 1 {
             dateString = "오후 \(String(format: "%02d", hour - 12)):\(String(format: "%02d", minutes))"
         } else if hour - 12 == 0 {
-            dateString = "정오 12:\(String(format: "%02d", minutes))"
+            dateString = "오후 12:\(String(format: "%02d", minutes))"
         } else {
             dateString = "오전 \(String(format: "%02d", hour)):\(String(format: "%02d", minutes))"
         }


### PR DESCRIPTION
### PR Type

- [x]  기능 추가 🔨
- [ ]  버그 수정 🐞
- [ ]  리팩토링 🚧
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [ ]  테스트 🔍
 

### Related Issue(작업 내용)
- close #315

### 참고 사항
- 채팅방을 들어 갔다가 나와도 firebase에서 해당 컬렉션 listener에 추가되어 readUserIDs에 추가가 되어 계속 미뤄두었던 listening 취소를 stopObserving 메서드로 구현하였습니다.
