### PR TITLE
프로필 화면 내비게이션 바 히든 이슈

### DIFF
--- a/Mogakco/Sources/Presentation/Common/Coordinator/ProfileCoordinator.swift
+++ b/Mogakco/Sources/Presentation/Common/Coordinator/ProfileCoordinator.swift
@@ -48,6 +48,7 @@ final class ProfileCoordinator: BaseCoordinator<ProfileCoordinatorResult> {
     func showProfile() {
         guard let viewModel = DIContainer.shared.container.resolve(ProfileViewModel.self) else { return }
         viewModel.type.onNext(type)
+        viewModel.navigationBarHidden.onNext(hideTabbar ? false : true)
         
         viewModel.navigation
             .subscribe(onNext: { [weak self] in
@@ -112,7 +113,6 @@ final class ProfileCoordinator: BaseCoordinator<ProfileCoordinatorResult> {
             .disposed(by: disposeBag)
         
         let viewController = WithdrawViewController(viewModel: viewModel)
-        
         pushTabbar(viewController, animated: true)
     }
     
@@ -120,7 +120,6 @@ final class ProfileCoordinator: BaseCoordinator<ProfileCoordinatorResult> {
     
     func showEditProfile() {
         guard let viewModel = DIContainer.shared.container.resolve(EditProfileViewModel.self) else { return }
-
         viewModel.type.onNext(.edit)
         
         viewModel.navigation

--- a/Mogakco/Sources/Presentation/Common/Coordinator/ProfileCoordinator.swift
+++ b/Mogakco/Sources/Presentation/Common/Coordinator/ProfileCoordinator.swift
@@ -60,7 +60,7 @@ final class ProfileCoordinator: BaseCoordinator<ProfileCoordinatorResult> {
                 case let .chatRoom(id):
                     self?.showChatRoom(id: id)
                 case .setting:
-                    self?.setting()
+                    self?.showSetting()
                 case .back:
                     self?.finish.onNext(.back)
                 }
@@ -78,44 +78,20 @@ final class ProfileCoordinator: BaseCoordinator<ProfileCoordinatorResult> {
     
     // MARK: - 설정화면
     
-    func setting() {
-        guard let viewModel = DIContainer.shared.container.resolve(SettingViewModel.self) else { return }
-        
-        viewModel.navigation
+    func showSetting() {
+        let setting = SettingCoordinator(navigationController)
+        coordinate(to: setting)
             .subscribe(onNext: { [weak self] in
                 switch $0 {
-                case .withdraw:
-                    self?.showWithdraw()
-                case .logout:
+                case .finish:
                     self?.finish.onNext(.finish)
                 case .back:
-                    self?.popTabbar(animated: true)
+                    break
                 }
             })
             .disposed(by: disposeBag)
-        
-        let viewController = SettingViewController(viewModel: viewModel)
-        pushTabbar(viewController, animated: true)
     }
-    
-    func showWithdraw() {
-        guard let viewModel = DIContainer.shared.container.resolve(WithdrawViewModel.self) else { return }
-        
-        viewModel.navigation
-            .subscribe(onNext: { [weak self] in
-                switch $0 {
-                case .success:
-                    self?.finish.onNext(.finish)
-                case .back:
-                    self?.popTabbar(animated: true)
-                }
-            })
-            .disposed(by: disposeBag)
-        
-        let viewController = WithdrawViewController(viewModel: viewModel)
-        pushTabbar(viewController, animated: true)
-    }
-    
+
     // MARK: - 프로필 수정
     
     func showEditProfile() {

--- a/Mogakco/Sources/Presentation/Common/Coordinator/SettingCoordinator.swift
+++ b/Mogakco/Sources/Presentation/Common/Coordinator/SettingCoordinator.swift
@@ -1,0 +1,68 @@
+//
+//  SettingCoordinator.swift
+//  Mogakco
+//
+//  Created by 신소민 on 2022/12/12.
+//  Copyright © 2022 Mogakco. All rights reserved.
+//
+
+import UIKit
+
+import RxSwift
+
+enum SettingCoordinatorResult {
+    case finish
+    case back
+}
+
+final class SettingCoordinator: BaseCoordinator<SettingCoordinatorResult> {
+    
+    private let finish = PublishSubject<SettingCoordinatorResult>()
+    
+    override func start() -> Observable<SettingCoordinatorResult> {
+        showSetting()
+        return finish.do(onNext: { [weak self] _ in self?.popTabbar(animated: false) })
+    }
+    
+    // MARK: - 설정화면
+    
+    func showSetting() {
+        guard let viewModel = DIContainer.shared.container.resolve(SettingViewModel.self) else { return }
+        
+        viewModel.navigation
+            .subscribe(onNext: { [weak self] in
+                switch $0 {
+                case .withdraw:
+                    self?.showWithdraw()
+                case .logout:
+                    self?.finish.onNext(.finish)
+                case .back:
+                    self?.popTabbar(animated: true)
+                }
+            })
+            .disposed(by: disposeBag)
+        
+        let viewController = SettingViewController(viewModel: viewModel)
+        pushTabbar(viewController, animated: true)
+    }
+    
+    // MARK: - 회원탈퇴
+    
+    func showWithdraw() {
+        guard let viewModel = DIContainer.shared.container.resolve(WithdrawViewModel.self) else { return }
+        
+        viewModel.navigation
+            .subscribe(onNext: { [weak self] in
+                switch $0 {
+                case .success:
+                    self?.finish.onNext(.finish)
+                case .back:
+                    self?.popTabbar(animated: true)
+                }
+            })
+            .disposed(by: disposeBag)
+        
+        let viewController = WithdrawViewController(viewModel: viewModel)
+        pushTabbar(viewController, animated: true)
+    }
+}

--- a/Mogakco/Sources/Presentation/Profile/ViewController/ProfileViewController.swift
+++ b/Mogakco/Sources/Presentation/Profile/ViewController/ProfileViewController.swift
@@ -125,7 +125,6 @@ final class ProfileViewController: UIViewController {
         view.backgroundColor = .mogakcoColor.backgroundDefault
         layout()
         bind()
-        navigationItem.leftBarButtonItem = UIBarButtonItem(customView: backButton)
     }
     
     func bind() {
@@ -252,10 +251,8 @@ final class ProfileViewController: UIViewController {
     private func bindNavigation(output: ProfileViewModel.Output) {
         rx.viewWillAppear
             .withLatestFrom(output.navigationBarHidden)
-            .debug()
-            .subscribe(onNext: { [weak self] in
-                self?.navigationController?.setNavigationBarHidden($0, animated: true)
-            })
+            .withUnretained(self)
+            .subscribe(onNext: { $0.0.setupNavigationBar(hidden: $0.1) })
             .disposed(by: disposeBag)
     }
     
@@ -275,6 +272,21 @@ final class ProfileViewController: UIViewController {
                 )
             })
             .disposed(by: disposeBag)
+    }
+    
+    func setupNavigationBar(hidden: Bool) {
+        navigationController?.setNavigationBarHidden(hidden, animated: true)
+        if !hidden {
+            title = "프로필"
+            headerView.isHidden = true
+            settingButton.removeFromSuperview()
+            navigationItem.leftBarButtonItem = UIBarButtonItem(customView: backButton)
+            navigationItem.rightBarButtonItem = UIBarButtonItem(customView: settingButton)
+            scrollView.snp.remakeConstraints {
+                $0.top.equalTo(view.safeAreaLayoutGuide.snp.top)
+                $0.leading.trailing.bottom.equalTo(view.safeAreaLayoutGuide)
+            }
+        }
     }
     
     func layout() {

--- a/Mogakco/Sources/Presentation/Profile/ViewController/ProfileViewController.swift
+++ b/Mogakco/Sources/Presentation/Profile/ViewController/ProfileViewController.swift
@@ -282,7 +282,7 @@ final class ProfileViewController: UIViewController {
             settingButton.removeFromSuperview()
             navigationItem.leftBarButtonItem = UIBarButtonItem(customView: backButton)
             navigationItem.rightBarButtonItem = UIBarButtonItem(customView: settingButton)
-            scrollView.snp.remakeConstraints {
+            skeletonContentsView.snp.remakeConstraints {
                 $0.top.equalTo(view.safeAreaLayoutGuide.snp.top)
                 $0.leading.trailing.bottom.equalTo(view.safeAreaLayoutGuide)
             }
@@ -322,8 +322,7 @@ final class ProfileViewController: UIViewController {
     private func layoutScrollView() {
         skeletonContentsView.addSubview(scrollView)
         scrollView.snp.makeConstraints {
-            $0.top.equalTo(headerView.snp.bottom)
-            $0.leading.trailing.bottom.equalToSuperview()
+            $0.top.leading.trailing.bottom.equalToSuperview()
         }
         
         scrollView.addSubview(contentStackView)

--- a/Mogakco/Sources/Presentation/Profile/ViewModel/ProfileViewModel.swift
+++ b/Mogakco/Sources/Presentation/Profile/ViewModel/ProfileViewModel.swift
@@ -42,6 +42,7 @@ final class ProfileViewModel: ViewModel {
         let hashtagEditButtonTapped: Observable<KindHashtag>
         let settingButtonTapped: Observable<Void>
         let reportButtonTapped: Observable<Void>
+        let backButtonTapped: Observable<Void>
     }
     
     struct Output {
@@ -56,6 +57,7 @@ final class ProfileViewModel: ViewModel {
         let studyRatingList: Driver<[(String, Int)]>
         let isLoading: Driver<Bool>
         let alert: Signal<Alert>
+        let navigationBarHidden: Signal<Bool>
     }
     
     var userUseCase: UserUseCaseProtocol?
@@ -64,6 +66,7 @@ final class ProfileViewModel: ViewModel {
     let navigation = PublishSubject<ProfileNavigation>()
     var disposeBag = DisposeBag()
     let type = BehaviorSubject<ProfileType>(value: .current)
+    let navigationBarHidden = BehaviorSubject<Bool>(value: false)
     private let user = BehaviorSubject<User?>(value: nil)
     private let studyRatingList = BehaviorSubject<[(String, Int)]>(value: [])
     private let isLoading = BehaviorSubject(value: true)
@@ -98,7 +101,8 @@ final class ProfileViewModel: ViewModel {
                 .asDriver(onErrorJustReturn: []),
             studyRatingList: studyRatingList.asDriver(onErrorJustReturn: []),
             isLoading: isLoading.asDriver(onErrorJustReturn: false),
-            alert: alert.asSignal(onErrorSignalWith: .empty())
+            alert: alert.asSignal(onErrorSignalWith: .empty()),
+            navigationBarHidden: navigationBarHidden.asSignal(onErrorJustReturn: false)
         )
     }
     
@@ -206,6 +210,11 @@ final class ProfileViewModel: ViewModel {
             .withUnretained(self)
             .flatMap { $0.0.reportUseCase?.reportUser(id: $0.1.id) ?? .empty() }
             .map { _ in .back }
+            .bind(to: navigation)
+            .disposed(by: disposeBag)
+        
+        input.backButtonTapped
+            .map { .back }
             .bind(to: navigation)
             .disposed(by: disposeBag)
     }

--- a/Mogakco/Sources/Presentation/Profile/ViewModel/ProfileViewModel.swift
+++ b/Mogakco/Sources/Presentation/Profile/ViewModel/ProfileViewModel.swift
@@ -171,11 +171,6 @@ final class ProfileViewModel: ViewModel {
             .bind(to: navigation)
             .disposed(by: disposeBag)
         
-        input.editProfileButtonTapped
-            .map { .editProfile }
-            .bind(to: navigation)
-            .disposed(by: disposeBag)
-        
         input.chatButtonTapped
             .withLatestFrom(user.compactMap { $0 })
             .flatMap { [weak self] in self?.createChatRoomUseCase?.create(otherUser: $0) ?? .empty() }


### PR DESCRIPTION
### PR Type

- [ ]  기능 추가 🔨
- [X]  버그 수정 🐞
- [X]  리팩토링 🚧
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [ ]  테스트 🔍
 

### Related Issue(작업 내용)

> 이슈 번호와 구현 내용 및 작업 했던 내역을 입력해주세요!
> 
- close #375
    - ProfileViewModel로 내비게이션 바 히든을 위한 데이터를 넘겨주도록 변경했습니다.
    - +) 프로필 화면으로 들어갈 때 헤더가 나타나지 않도록 수정했습니다.
    - 프로필 편집 버튼 선택 시 화면이 두 번 들어가지는 오류를 해결했습니다.
    - 설정과 관련된 화면들을 SettingCoordinator로 분리했습니다.

### Screenshots
<img src="https://user-images.githubusercontent.com/109145755/206977402-4c3a7ea7-7c07-4b40-84da-b95d3998dc00.png" width="40%"/>