### PR TITLE
스터디 사이드바 메뉴 오류 해결

### DIFF
--- a/Mogakco/Sources/Data/Repositories/StudyRepository.swift
+++ b/Mogakco/Sources/Data/Repositories/StudyRepository.swift
@@ -195,9 +195,13 @@ struct StudyRepository: StudyRepositoryProtocol {
                         request: UpdateUserIDsRequestDTO(
                             userIDs: chatRoom.userIDs.filter { $0 != user.id }
                         )
-                    ) ?? .empty()
+                    )
+                    ?? .empty()
                 }
-                .flatMap { _ in pushNotificationService?.unsubscribeTopic(topic: id) ?? .empty() }
+                .map { _ in () }
+                .catchAndReturn(()) // 스터디가 없는 채팅방 있을 수 있음
+                .flatMap { pushNotificationService?.unsubscribeTopic(topic: id) ?? .empty() }
+                
             
             Observable.combineLatest(
                 updateUser,

--- a/Mogakco/Sources/Presentation/Chat/View/ChatCell.swift
+++ b/Mogakco/Sources/Presentation/Chat/View/ChatCell.swift
@@ -166,13 +166,13 @@ final class ChatCell: UICollectionViewCell, Identifiable {
         if let user = user {
             nameLabel.text = user.name
         } else {
-            nameLabel.text = "탈퇴한 유저"
+            nameLabel.text = "알 수 없음"
         }
         
         if let url = URL(string: user?.profileImageURLString ?? "") {
             profileImageView.load(url: url)
         } else {
-            profileImageView.image = UIImage(systemName: "person.fill")
+            profileImageView.image = Image.profileDefault
         }
     }
     

--- a/Mogakco/Sources/Presentation/Chat/View/ChatSidebarTableViewCell.swift
+++ b/Mogakco/Sources/Presentation/Chat/View/ChatSidebarTableViewCell.swift
@@ -18,7 +18,7 @@ final class ChatSidebarTableViewCell: UITableViewCell, Identifiable {
     var menuLabel = UILabel().then {
         $0.textAlignment = .left
         $0.font = .mogakcoFont.mediumRegular
-        $0.textColor = .mogakcoColor.primaryDefault
+        $0.textColor = .mogakcoColor.typographyPrimary
     }
     
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {

--- a/Mogakco/Sources/Presentation/Chat/View/ChatSidebarView.swift
+++ b/Mogakco/Sources/Presentation/Chat/View/ChatSidebarView.swift
@@ -17,13 +17,14 @@ enum ChatSidebarMenu: String, CaseIterable {
     
     case studyInfo = "스터디 정보"
     case exitStudy = "나가기"
-    case showMember = "멤버 보기"
+    // case showMember = "멤버 보기"
 
     init(row: Int) {
         switch row {
         case 0: self = .studyInfo
         case 1: self = .exitStudy
-        default: self = .showMember
+        // default: self = .showMember
+        default: self = .studyInfo
         }
     }
 }
@@ -66,7 +67,7 @@ final class ChatSidebarView: UIView {
         
         tableView.snp.makeConstraints {
             $0.top.equalToSuperview().offset(80)
-            $0.left.bottom.right.equalToSuperview()
+            $0.left.bottom.right.equalToSuperview().inset(8.0)
         }
     }
 }

--- a/Mogakco/Sources/Presentation/Chat/ViewController/ChatViewController.swift
+++ b/Mogakco/Sources/Presentation/Chat/ViewController/ChatViewController.swift
@@ -104,7 +104,7 @@ final class ChatViewController: UIViewController {
                 .throttle(.seconds(1), scheduler: MainScheduler.asyncInstance),
             studyInfoButtonDidTap: studyInfoButton.rx.tap
                 .throttle(.seconds(1), scheduler: MainScheduler.asyncInstance),
-            selectedSidebar: sidebarView.tableView.rx.itemSelected
+            selectedSidebar: sidebarView.tableView.rx.modelSelected(ChatSidebarMenu.self)
                 .throttle(.seconds(1), scheduler: MainScheduler.asyncInstance),
             sendButtonDidTap: messageInputView.sendButton.rx.tap
                 .throttle(.seconds(1), scheduler: MainScheduler.asyncInstance),
@@ -207,7 +207,8 @@ final class ChatViewController: UIViewController {
             })
             .disposed(by: disposeBag)
         
-        output.selectedSidebar
+        sidebarView.tableView.rx.itemSelected
+            .asSignal()
             .emit(onNext: { [weak self] _ in
                 self?.hideSidebarView()
             })
@@ -229,8 +230,8 @@ final class ChatViewController: UIViewController {
     
     private func configureSideBar() {
         sidebarView.layer.zPosition = Constant.sidebarZPosition
-        sidebarView.tableView.delegate = nil
-        sidebarView.tableView.dataSource = nil
+        // sidebarView.tableView.delegate = nil
+        // sidebarView.tableView.dataSource = nil
         self.view.isUserInteractionEnabled = true
     }
     


### PR DESCRIPTION
### PR Type

- [x]  기능 추가 🔨
- [x]  버그 수정 🐞
- [ ]  리팩토링 🚧
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [ ]  테스트 🔍
 

### Related Issue(작업 내용)

- 채팅방 내 사이드바 메뉴가 바인딩되지 않는 오류를 해결하였습니다
- 채팅방 나가기 시 Alert으로 한번 더 확인 후 나가도록 수정하였습니다
- 채팅방 나가기 시 스터디가 없는 채팅방 제거 중 오류가 발생에 대한 예외처리를 하였습니다.
- 스터디 상세보기 이동을 구현하였습니다.
- 탈퇴한 유저 이미지를 Constant - profileDefault로 변경하였습니다.

### Screenshots(Optional)

https://user-images.githubusercontent.com/73675540/207056237-339efa98-039a-4551-b419-9ee8fad2f267.mp4

https://user-images.githubusercontent.com/73675540/207056229-250b7aaa-45ec-44e4-8b7d-52cb6e8a15f0.mp4

