### PR TITLE
채팅방 및 프로필 UI 오류 수정

### DIFF
--- a/Mogakco/Sources/Domain/UseCases/ChatUseCase.swift
+++ b/Mogakco/Sources/Domain/UseCases/ChatUseCase.swift
@@ -45,6 +45,7 @@ struct ChatUseCase: ChatUseCaseProtocol {
                     chat.isFromCurrentUser = chatUser.id == myUser.id
                     return chat
                 }
+                .catchAndReturn(chat)
             } ?? .empty()
     }
     

--- a/Mogakco/Sources/Domain/UseCases/UserUseCase.swift
+++ b/Mogakco/Sources/Domain/UseCases/UserUseCase.swift
@@ -36,9 +36,17 @@ struct UserUseCase: UserUseCaseProtocol {
     }
     
     func studyRatingList(studyIDs: [String]) -> Observable<[(String, Int)]> {
-        return studyRepository?.list(ids: studyIDs)
+        return (studyRepository?.list(ids: studyIDs) ?? .empty())
             .map { $0.map { $0.category } }
             .map { $0.countDictionary }
-            .map { $0.sorted { $0.value < $1.value }.map { ($0.key, $0.value) } } ?? .empty()
+            .map { $0.sorted {
+                if $0.value != $1.value {
+                    return $0.value < $1.value
+                } else {
+                    return $0.key < $1.key
+                }
+            }.map {
+                ($0.key, $0.value) }
+            }
     }
 }

--- a/Mogakco/Sources/Presentation/Chat/View/ChatRoomTableViewCell.swift
+++ b/Mogakco/Sources/Presentation/Chat/View/ChatRoomTableViewCell.swift
@@ -39,6 +39,9 @@ final class ChatRoomTableViewCell: UITableViewCell, Identifiable {
         $0.textAlignment = .right
         $0.font = UIFont.mogakcoFont.smallRegular
         $0.textColor = UIColor.mogakcoColor.typographySecondary
+        $0.snp.makeConstraints {
+            $0.width.equalTo(80.0)
+        }
     }
     
     private let unreadMessageCountLabel = UILabel().then {


### PR DESCRIPTION
### PR Type

- [ ]  기능 추가 🔨
- [x]  버그 수정 🐞
- [ ]  리팩토링 🚧
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [ ]  테스트 🔍
 

### Related Issue(작업 내용)

- 채팅방에 탈퇴한 유저가 있을 시 유저 정보 호출 과정에 오류가 나면 Alert이 작동하고 있어 예외처리를 진행하였습니다.
- 채팅방 최근 메세지 날짜 길이 오류를 수정하였습니다
- resolve #403 
  - 프로필 Top3 정렬 기준을 재설정하여 리로드 시 변동 오류를 수정하였습니다.
