### PR TITLE
스터디 목록 리로드 시점 분리, 최대 인원 수 참가하지 못하도록 수정

### DIFF
--- a/Mogakco/Sources/Presentation/Chat/ViewController/ChatViewController.swift
+++ b/Mogakco/Sources/Presentation/Chat/ViewController/ChatViewController.swift
@@ -32,7 +32,6 @@ final class ChatViewController: UIViewController {
     
     private lazy var messageInputView = MessageInputView().then {
         $0.frame = CGRect(x: 0, y: 0, width: view.frame.width, height: 0)
-        $0.backgroundColor = .red
     }
     
     private lazy var collectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout()

--- a/Mogakco/Sources/Presentation/Common/Coordinator/StudyListCoordinator.swift
+++ b/Mogakco/Sources/Presentation/Common/Coordinator/StudyListCoordinator.swift
@@ -33,21 +33,21 @@ final class StudyListCoordinator: BaseCoordinator<StudyListCoordinatorResult> {
                 switch $0 {
                 case .create:
                     self?.showCreateStudy()
-                case .detail(let id):
+                case let .detail(id):
                     self?.showStudyDetail(id: id)
-                case .sort:
-                    self?.showStudySort(sortObserver: viewModel.sort.asObserver())
-                case .languageFilter:
+                case let .sort(observer):
+                    self?.showStudySort(sortObserver: observer)
+                case let .languageFilter(hashtags, observer):
                     self?.showHashtag(
                         kind: .language,
-                        selectedHashtag: [],
-                        hashtagObserver: viewModel.languageFilter.asObserver()
+                        selectedHashtag: hashtags,
+                        hashtagObserver: observer
                     )
-                case .categoryFilter:
+                case let .categoryFilter(hashtags, observer):
                     self?.showHashtag(
                         kind: .category,
-                        selectedHashtag: [],
-                        hashtagObserver: viewModel.categoryFilter.asObserver()
+                        selectedHashtag: hashtags,
+                        hashtagObserver: observer
                     )
                 }
             })

--- a/Mogakco/Sources/Presentation/Study/View/StudyCell.swift
+++ b/Mogakco/Sources/Presentation/Study/View/StudyCell.swift
@@ -72,6 +72,7 @@ final class StudyCell: UICollectionViewCell, Identifiable {
     
     private let participantsView = StudyInfoView(frame: .zero).then {
         $0.textLabel.text = "2/3 참여"
+        $0.imageView.image = UIImage(systemName: "person.fill")
     }
     
     private lazy var midStackView = UIStackView().then { stack in

--- a/Mogakco/Sources/Presentation/Study/ViewController/StudyDetailViewController.swift
+++ b/Mogakco/Sources/Presentation/Study/ViewController/StudyDetailViewController.swift
@@ -27,6 +27,7 @@ final class StudyDetailViewController: UIViewController {
     }
     private let participantsView = StudyInfoView(frame: .zero).then {
         $0.textLabel.text = "2/3 참여"
+        $0.imageView.image = UIImage(systemName: "person.fill")
     }
     
     private let locationView = StudyInfoView(frame: .zero).then {

--- a/Mogakco/Sources/Presentation/Study/ViewModel/StudyListViewModel.swift
+++ b/Mogakco/Sources/Presentation/Study/ViewModel/StudyListViewModel.swift
@@ -66,7 +66,7 @@ final class StudyListViewModel: ViewModel {
     
     func bindRefresh(input: Input) {
         refresh
-            .debounce(.seconds(1), scheduler: MainScheduler.instance)
+            .debounce(.milliseconds(500), scheduler: MainScheduler.instance)
             .withLatestFrom(Observable.combineLatest(sort, filters)) { ($0, $1) }
             .flatMap { [weak self] delay, arguments -> Observable<Result<[Study], Error>> in
                 let (sort, filters) = arguments
@@ -110,7 +110,7 @@ final class StudyListViewModel: ViewModel {
     
     func bindFilterSort(input: Input) {
         Observable.combineLatest(sort.skip(1), filters.skip(1))
-            .debounce(.milliseconds(500), scheduler: MainScheduler.instance)
+            .debounce(.milliseconds(100), scheduler: MainScheduler.instance)
             .map { _ in return 0 }
             .withUnretained(self)
             .subscribe(onNext: { $0.0.refresh.onNext($0.1) })

--- a/Mogakco/Sources/Presentation/Study/ViewModel/StudyListViewModel.swift
+++ b/Mogakco/Sources/Presentation/Study/ViewModel/StudyListViewModel.swift
@@ -109,16 +109,11 @@ final class StudyListViewModel: ViewModel {
     }
     
     func bindFilterSort(input: Input) {
-        sort
-            .skip(1)
+        Observable.combineLatest(sort.skip(1), filters.skip(1))
+            .debounce(.milliseconds(500), scheduler: MainScheduler.instance)
             .map { _ in return 0 }
-            .bind(to: refresh)
-            .disposed(by: disposeBag)
-        
-        filters
-            .skip(1)
-            .map { _ in return 0 }
-            .bind(to: refresh)
+            .withUnretained(self)
+            .subscribe(onNext: { $0.0.refresh.onNext($0.1) })
             .disposed(by: disposeBag)
         
         input.resetButtonTapped

--- a/Mogakco/Sources/Presentation/Study/ViewModel/StudyListViewModel.swift
+++ b/Mogakco/Sources/Presentation/Study/ViewModel/StudyListViewModel.swift
@@ -66,7 +66,7 @@ final class StudyListViewModel: ViewModel {
     
     func bindRefresh(input: Input) {
         refresh
-            .throttle(.seconds(1), latest: false, scheduler: MainScheduler.instance)
+            .debounce(.seconds(1), scheduler: MainScheduler.instance)
             .withLatestFrom(Observable.combineLatest(sort, filters)) { ($0, $1) }
             .flatMap { [weak self] delay, arguments -> Observable<Result<[Study], Error>> in
                 let (sort, filters) = arguments


### PR DESCRIPTION
### PR Type

- [ ]  기능 추가 🔨
- [X]  버그 수정 🐞
- [ ]  리팩토링 🚧
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [ ]  테스트 🔍
 

### Related Issue(작업 내용)

> 이슈 번호와 구현 내용 및 작업 했던 내역을 입력해주세요!
> 
- close #435 
    - 처음 스터디 목록을 불러올 때만 3초의 딜레이가 있도록 수정했습니다.

- 스터디 인원 수를 초과하여 참가하지 못하도록 수정했습니다.

- 스터디 목록, 디테일 화면에서 프로필 아이콘이 표시되지 않던 문제를 해결했습니다.

### Screenshots(Optional)
<img src="https://user-images.githubusercontent.com/109145755/208008215-159ec60c-3e0d-4b96-b004-c9ecbd48520c.png" width="50%">